### PR TITLE
New Storage Types

### DIFF
--- a/ODS/Compression/Compressor.cs
+++ b/ODS/Compression/Compressor.cs
@@ -1,4 +1,6 @@
-﻿namespace ODS.Compression
+﻿using System.IO;
+
+namespace ODS.Compression
 {
     /**
      * <summary>
@@ -13,13 +15,13 @@
          * <param name="data">The array of bytes to compress.</param>
          * <returns>The array of compressed bytes.</returns>
          */
-        byte[] Compress(byte[] data);
+         Stream GetCompressStream(Stream stream);
 
         /**
          * <summary>Decompress an array of bytes.</summary>
          * <param name="data">The array of bytes to decompress.</param>
          * <returns>The array of decompressed bytes.</returns>
          */
-        byte[] Decompress(byte[] data);
+        Stream GetDecompressStream(Stream stream);
     }
 }

--- a/ODS/Compression/GZIPCompression.cs
+++ b/ODS/Compression/GZIPCompression.cs
@@ -6,7 +6,7 @@ namespace ODS.Compression
     /**
      * <summary>Compress the file using the GZIP compression format.</summary>
      */
-    public class GZIPCompression : Compressor
+    public class GZIPCompression : ICompressor
     {
 
         public Stream GetCompressStream(Stream stream)

--- a/ODS/Compression/GZIPCompression.cs
+++ b/ODS/Compression/GZIPCompression.cs
@@ -8,23 +8,15 @@ namespace ODS.Compression
      */
     public class GZIPCompression : Compressor
     {
-        public byte[] Compress(byte[] data)
+
+        public Stream GetCompressStream(Stream stream)
         {
-            MemoryStream stream = new MemoryStream();
-            GZipStream zipStream = new GZipStream(stream, CompressionMode.Compress);
-            zipStream.Write(data, 0, data.Length);
-            zipStream.Close();
-            return stream.ToArray();
+            return new GZipStream(stream, CompressionMode.Compress, true);
         }
 
-        public byte[] Decompress(byte[] data)
+        public Stream GetDecompressStream(Stream stream)
         {
-            MemoryStream stream = new MemoryStream(data);
-            GZipStream zipStream = new GZipStream(stream, CompressionMode.Decompress);
-            MemoryStream output = new MemoryStream();
-            zipStream.CopyTo(output);
-            zipStream.Close();
-            return output.ToArray();
+            return new GZipStream(stream, CompressionMode.Decompress, true);
         }
     }
 }

--- a/ODS/Compression/ICompressor.cs
+++ b/ODS/Compression/ICompressor.cs
@@ -8,7 +8,7 @@ namespace ODS.Compression
      * Unlike the Java version of ODS, an input stream is not needed.
      * </summary>
      */
-    public interface Compressor
+    public interface ICompressor
     {
         /**
          * <summary>Compress an array of bytes.</summary>

--- a/ODS/Compression/NoCompression.cs
+++ b/ODS/Compression/NoCompression.cs
@@ -5,14 +5,14 @@
      */
     public class NoCompression : Compressor
     {
-        public byte[] Compress(byte[] data)
+        public System.IO.Stream GetCompressStream(System.IO.Stream stream)
         {
-            return data;
+            return stream;
         }
 
-        public byte[] Decompress(byte[] data)
+        public System.IO.Stream GetDecompressStream(System.IO.Stream stream)
         {
-            return data;
+            return stream;
         }
     }
 }

--- a/ODS/Compression/NoCompression.cs
+++ b/ODS/Compression/NoCompression.cs
@@ -3,7 +3,7 @@
     /**
      * <summary>This will not compress the file.</summary>
      */
-    public class NoCompression : Compressor
+    public class NoCompression : ICompressor
     {
         public System.IO.Stream GetCompressStream(System.IO.Stream stream)
         {

--- a/ODS/Compression/ZLIBCompression.cs
+++ b/ODS/Compression/ZLIBCompression.cs
@@ -6,7 +6,7 @@ namespace ODS.Compression
     /**
      * <summary>Compress the file using the ZLIB compression format.</summary>
      */
-    public class ZLIBCompression : Compressor
+    public class ZLIBCompression : ICompressor
     {
         public System.IO.Stream GetCompressStream(System.IO.Stream stream)
         {

--- a/ODS/Compression/ZLIBCompression.cs
+++ b/ODS/Compression/ZLIBCompression.cs
@@ -8,23 +8,14 @@ namespace ODS.Compression
      */
     public class ZLIBCompression : Compressor
     {
-        public byte[] Compress(byte[] data)
+        public System.IO.Stream GetCompressStream(System.IO.Stream stream)
         {
-            MemoryStream stream = new MemoryStream();
-            DeflaterOutputStream zipStream = new DeflaterOutputStream(stream);
-            zipStream.Write(data, 0, data.Length);
-            zipStream.Close();
-            return stream.ToArray();
+            return new DeflaterOutputStream(stream);
         }
 
-        public byte[] Decompress(byte[] data)
+        public System.IO.Stream GetDecompressStream(System.IO.Stream stream)
         {
-            MemoryStream stream = new MemoryStream(data);
-            InflaterInputStream zipStream = new InflaterInputStream(stream);
-            MemoryStream output = new MemoryStream();
-            zipStream.CopyTo(output);
-            zipStream.Close();
-            return output.ToArray();
+            return new InflaterInputStream(stream);
         }
     }
 }

--- a/ODS/Exceptions/ODSException.cs
+++ b/ODS/Exceptions/ODSException.cs
@@ -4,6 +4,9 @@ using System.Text;
 
 namespace ODS.Exceptions
 {
+    /**
+     * <summary>The standard ODS exception.</summary>
+     */
     class ODSException : Exception
     {
         public ODSException() { }

--- a/ODS/ITag.cs
+++ b/ODS/ITag.cs
@@ -1,4 +1,4 @@
-﻿using ODS.Stream;
+﻿using ODS.ODSStreams;
 
 namespace ODS
 {

--- a/ODS/Internal/InternalUtils.cs
+++ b/ODS/Internal/InternalUtils.cs
@@ -8,11 +8,23 @@ using ODS.Util;
 
 namespace ODS.Internal
 {
+    /**
+     * <summary>This class serves as a utility class for the internals of ODS.</summary>
+     */
     class InternalUtils
     {
         /**
-         * Used to get a tag from the file.
+         * <summary>
+         * Get a tag from a stream via a name.
+         * 
+         * <para>This method is deprecated. Use <see cref="GetSubObjectData(Stream, string)"/> instead.</para>
+         * 
+         * </summary>
+         * 
+         * <param name="stream">The stream to look for the tag in.</param>
+         * <param name="name">The name of the object to find. (This is not the key!)</param>
          */
+        [Obsolete]
         public static ITag getSubData(Stream stream, string name)
         {
             BigBinaryReader binReader = new BigBinaryReader(stream);
@@ -52,9 +64,13 @@ namespace ODS.Internal
         }
 
         /**
-         * Used to get a tag from the file using the key system.
+         * <summary>Get a tag from a stream using the key system.</summary>
+         * 
+         * <param name="stream">The stream to read from. (Position is expected to be at 0.)</param>
+         * <param name="key">The key of the tag that you want to find.</param>
+         * <returns>Returns the desired tag.</returns>
          */
-        public static ITag getSubObjectData(Stream stream, string key)
+        public static ITag GetSubObjectData(Stream stream, string key)
         {
             BigBinaryReader binReader = new BigBinaryReader(stream);
             TagBuilder currentBuilder = new TagBuilder();
@@ -89,7 +105,7 @@ namespace ODS.Internal
                 }
 
                 if (otherKey != null)
-                    return getSubObjectData(stream, otherKey);
+                    return GetSubObjectData(stream, otherKey);
 
                 byte[] value = binReader.ReadBytes((int)(currentBuilder.getStartingIndex() - stream.Position) + (int)currentBuilder.getDataSize());
                 currentBuilder.setValueBytes(value);
@@ -110,9 +126,13 @@ namespace ODS.Internal
         }
 
         /**
-         * This is used to find the tags using the key system.
+         * <summary>Checks to see if a key exists within a stream.</summary>
+         * <param name="stream">The stream to check in.</param>
+         * <param name="key">The key to find.</param>
+         * 
+         * <returns>If the key exists.</returns>
          */
-        public static bool findSubObjectData(Stream stream, string key)
+        public static bool FindSubObjectData(Stream stream, string key)
         {
             BigBinaryReader binReader = new BigBinaryReader(stream);
             TagBuilder currentBuilder = new TagBuilder();
@@ -149,7 +169,7 @@ namespace ODS.Internal
                 
 
                 if (otherKey != null)
-                    return findSubObjectData(stream, otherKey);
+                    return FindSubObjectData(stream, otherKey);
 
                 byte[] value = binReader.ReadBytes((int)(currentBuilder.getStartingIndex() - stream.Position) + (int)currentBuilder.getDataSize());
                 currentBuilder.setValueBytes(value);
@@ -161,7 +181,11 @@ namespace ODS.Internal
 
 
         /**
-         * This is used to delete tags from the list. This does not support key format.
+         * <summary>Delete a tag from an array of bytes using the KeyScout.</summary>
+         * 
+         * <param name="data">The byte array to remove data from.</param>
+         * <param name="counter">The KeyScout that contains information about the tag to remove.</param>
+         * <returns>The byte array after the deletion.</returns>
          */
         public static byte[] deleteSubObjectData(byte[] data, KeyScout counter)
         {
@@ -193,9 +217,9 @@ namespace ODS.Internal
          * Replace a tag with another tag.
          * </summary>
          * <param name="data">The input array of bytes</param>
-         * <param name="counter">The scout object</param>
+         * <param name="counter">The KeyScout object conatining the information of the tag to replace.</param>
          * <param name="dataToReplace">The bytes of the replacement data.</param>
-         * <returns>The output bytes.</returns>
+         * <returns>The byte array after the replacement.</returns>
          */
         public static byte[] ReplaceSubObjectData(byte[] data, KeyScout counter, byte[] dataToReplace)
         {
@@ -227,6 +251,14 @@ namespace ODS.Internal
             return array1;
         }
 
+        /**
+         * <summary>Insert in a new tag.</summary>
+         * <param name="data">The input array of bytes.</param>
+         * <param name="counter">The KeyScout object containing information of the tag to set.</param>
+         * <param name="dataToReplace">The bytes of the replacement data.</param>
+         * 
+         * <returns>The output bytes.</returns>
+         */
         public static byte[] SetSubObjectData(byte[] data, KeyScout counter, byte[] dataToReplace)
         {
             KeyScoutChild child = counter.GetChildren()[counter.GetChildren().Count - 1];
@@ -341,6 +373,7 @@ namespace ODS.Internal
         /**
          * <summary>Get a list of Tags from an array of bytes. This is meant for internal use only.</summary>
          * <param name="data">The array of bytes.</param>
+         * <returns>The list of tags.</returns>
          */
         public static List<T> GetListData<T>(byte[] data) where T : ITag
         {
@@ -351,8 +384,9 @@ namespace ODS.Internal
         }
 
         /**
-         * <summary>Get a list of Tags from an array of bytes. This is meant for internal use only.</summary>
-         * <param name="data">The array of bytes.</param>
+         * <summary>Get a list of Tags from a stream. This is meant for internal use only.</summary>
+         * <param name="stream">The stream to read from. (Position is expected to be at 0).</param>
+         * <returns>The list of tags.</returns>
          */
         public static List<T> GetListData<T>(Stream stream) where T : ITag
         {

--- a/ODS/Internal/InternalUtils.cs
+++ b/ODS/Internal/InternalUtils.cs
@@ -1,0 +1,383 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using System.IO;
+using ODS.ODSStreams;
+using ODS.Util;
+
+namespace ODS.Internal
+{
+    class InternalUtils
+    {
+        /**
+         * Used to get a tag from the file.
+         */
+        public static ITag getSubData(Stream stream, string name)
+        {
+            BigBinaryReader binReader = new BigBinaryReader(stream);
+            TagBuilder currentBuilder = new TagBuilder();
+
+
+            while (binReader.BaseStream.Position != binReader.BaseStream.Length)
+            {
+                currentBuilder.setDataType(binReader.ReadByte());
+                currentBuilder.setDataSize(binReader.ReadInt32());
+                //TODO see if this is correct.
+                currentBuilder.setStartingIndex(binReader.BaseStream.Position);
+                currentBuilder.setNameSize(binReader.ReadInt16());
+
+                if (currentBuilder.getNameSize() != Encoding.UTF8.GetByteCount(name))
+                {
+                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
+                    currentBuilder = new TagBuilder();
+                    continue;
+                }
+
+                byte[] nameBytes = binReader.ReadBytes(currentBuilder.getNameSize());
+                String tagName = Encoding.UTF8.GetString(nameBytes);
+                currentBuilder.setName(tagName);
+                if (tagName != name)
+                {
+                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
+                    currentBuilder = new TagBuilder();
+                    continue;
+                }
+
+                byte[] value = binReader.ReadBytes((int)(currentBuilder.getStartingIndex() - stream.Position) + (int)currentBuilder.getDataSize());
+                currentBuilder.setValueBytes(value);
+                return currentBuilder.proccess();
+            }
+            return null;
+        }
+
+        /**
+         * Used to get a tag from the file using the key system.
+         */
+        public static ITag getSubObjectData(Stream stream, string key)
+        {
+            BigBinaryReader binReader = new BigBinaryReader(stream);
+            TagBuilder currentBuilder = new TagBuilder();
+
+            string name = key.Split('.')[0];
+            string otherKey = getKey(key.Split('.'));
+
+
+            while (binReader.BaseStream.Position != binReader.BaseStream.Length)
+            {
+                currentBuilder.setDataType(binReader.ReadByte());
+                currentBuilder.setDataSize(binReader.ReadInt32());
+                //TODO see if this is correct.
+                currentBuilder.setStartingIndex(stream.Position);
+                currentBuilder.setNameSize(binReader.ReadInt16());
+
+                if (currentBuilder.getNameSize() != Encoding.UTF8.GetByteCount(name))
+                {
+                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
+                    currentBuilder = new TagBuilder();
+                    continue;
+                }
+
+                byte[] nameBytes = binReader.ReadBytes(currentBuilder.getNameSize());
+                string tagName = Encoding.UTF8.GetString(nameBytes);
+                currentBuilder.setName(tagName);
+                if (tagName != name)
+                {
+                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
+                    currentBuilder = new TagBuilder();
+                    continue;
+                }
+
+                if (otherKey != null)
+                    return getSubObjectData(stream, otherKey);
+
+                byte[] value = binReader.ReadBytes((int)(currentBuilder.getStartingIndex() - stream.Position) + (int)currentBuilder.getDataSize());
+                currentBuilder.setValueBytes(value);
+
+                return currentBuilder.proccess();
+            }
+            return null;
+        }
+
+        private static string getKey(string[] s)
+        {
+            List<string> list = new List<string>(s);
+            list.Remove(list[0]);
+            if (list.Count == 1) return list[0];
+            if (list.Count < 1) return null;
+
+            return string.Join(".", list);
+        }
+
+        /**
+         * This is used to find the tags using the key system.
+         */
+        public static bool findSubObjectData(Stream stream, string key)
+        {
+            BigBinaryReader binReader = new BigBinaryReader(stream);
+            TagBuilder currentBuilder = new TagBuilder();
+
+            string name = key.Split('.')[0];
+            string otherKey = getKey(key.Split('.'));
+
+
+            while (binReader.BaseStream.Position != binReader.BaseStream.Length)
+            {
+                currentBuilder.setDataType(binReader.ReadByte());
+                currentBuilder.setDataSize(binReader.ReadInt32());
+                //TODO see if this is correct.
+                currentBuilder.setStartingIndex(binReader.BaseStream.Position);
+                currentBuilder.setNameSize(binReader.ReadInt16());
+
+                if (currentBuilder.getNameSize() != Encoding.UTF8.GetByteCount(name))
+                {
+                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
+                    currentBuilder = new TagBuilder();
+                    continue;
+                }
+
+                byte[] nameBytes = binReader.ReadBytes(currentBuilder.getNameSize());
+                string tagName = Encoding.UTF8.GetString(nameBytes);
+                currentBuilder.setName(tagName);
+                if (tagName != name)
+                {
+                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
+                    currentBuilder = new TagBuilder();
+                    continue;
+                }
+
+                
+
+                if (otherKey != null)
+                    return findSubObjectData(stream, otherKey);
+
+                byte[] value = binReader.ReadBytes((int)(currentBuilder.getStartingIndex() - stream.Position) + (int)currentBuilder.getDataSize());
+                currentBuilder.setValueBytes(value);
+
+                return true;
+            }
+            return false;
+        }
+
+
+        /**
+         * This is used to delete tags from the list. This does not support key format.
+         */
+        public static byte[] deleteSubObjectData(byte[] data, KeyScout counter)
+        {
+            counter.RemoveAmount(counter.GetEnd().GetSize() + 5);
+
+            KeyScoutChild end = counter.GetEnd();
+
+            byte[] array1 = new byte[data.Length - (5 + end.GetSize())];
+            Array.Copy(data, 0, array1, 0, (end.GetStartingIndex() - 1));
+            Array.Copy(data, end.GetStartingIndex() + 4 + end.GetSize(),
+                array1, end.GetStartingIndex() - 1,
+                data.Length - (end.GetStartingIndex() + 4 + end.GetSize()));
+
+            foreach (KeyScoutChild child in counter.GetChildren())
+            {
+                int index = child.GetStartingIndex();
+                int size = child.GetSize();
+                array1[index] = (byte)(size >> 24);
+                array1[index + 1] = (byte)(size >> 16);
+                array1[index + 2] = (byte)(size >> 8);
+                array1[index + 3] = (byte)size;
+            }
+
+            return array1;
+        }
+
+        /**
+         * <summary>
+         * Replace a tag with another tag.
+         * </summary>
+         * <param name="data">The input array of bytes</param>
+         * <param name="counter">The scout object</param>
+         * <param name="dataToReplace">The bytes of the replacement data.</param>
+         * <returns>The output bytes.</returns>
+         */
+        public static byte[] ReplaceSubObjectData(byte[] data, KeyScout counter, byte[] dataToReplace)
+        {
+            counter.RemoveAmount(counter.GetEnd().GetSize() + 5);
+            counter.AddAmount(dataToReplace.Length);
+
+            KeyScoutChild end = counter.GetEnd();
+
+
+            byte[] array1 = new byte[data.Length - (5 + end.GetSize()) + dataToReplace.Length];
+            //Copy all of the information before the removed data.
+            Array.Copy(data, 0, array1, 0, (end.GetStartingIndex() - 1));
+            Array.Copy(dataToReplace, 0, array1, end.GetStartingIndex() - 1, dataToReplace.Length);
+            // copy all of the information after the removed data.
+            Array.Copy(data, end.GetStartingIndex() + 4 + end.GetSize(),
+                    array1, end.GetStartingIndex() - 1 + dataToReplace.Length,
+                    data.Length - (end.GetStartingIndex() + 4 + end.GetSize()));
+
+            foreach (KeyScoutChild child in counter.GetChildren())
+            {
+                int index = child.GetStartingIndex();
+                int size = child.GetSize();
+                array1[index] = (byte)(size >> 24);
+                array1[index + 1] = (byte)(size >> 16);
+                array1[index + 2] = (byte)(size >> 8);
+                array1[index + 3] = (byte)(size);
+            }
+
+            return array1;
+        }
+
+        public static byte[] SetSubObjectData(byte[] data, KeyScout counter, byte[] dataToReplace)
+        {
+            KeyScoutChild child = counter.GetChildren()[counter.GetChildren().Count - 1];
+
+
+            byte[] array1 = new byte[data.Length + dataToReplace.Length];
+            Array.Copy(data, 0, array1, 0, child.GetStartingIndex() + 4 + child.GetSize());
+            Array.Copy(dataToReplace, 0, array1, child.GetStartingIndex() + 4 + child.GetSize(), dataToReplace.Length);
+            Array.Copy(data, (child.GetStartingIndex() + 4 + child.GetSize()), array1, (child.GetStartingIndex() + 4 + child.GetSize()) + dataToReplace.Length,
+                    data.Length - (child.GetStartingIndex() + 4 + child.GetSize()));
+
+            counter.AddAmount(dataToReplace.Length);
+
+            foreach (KeyScoutChild childs in counter.GetChildren())
+            {
+                int index = childs.GetStartingIndex();
+                int size = childs.GetSize();
+                array1[index] = (byte)(size >> 24);
+                array1[index + 1] = (byte)(size >> 16);
+                array1[index + 2] = (byte)(size >> 8);
+                array1[index + 3] = (byte)(size);
+            }
+
+            return array1;
+        }
+
+        /**
+         * <summary>
+         * This object goes through the data and scouts out the information from the given key.
+         * This method is recursive, which is why the parameter offset exists.
+         * </summary>
+         * 
+         * <param name="data">The input array of bytes</param>
+         * <param name="key">The key</param>
+         * <param name="counter">The Scout object</param>
+         * <returns>The key scout.</returns>
+         */
+        public static KeyScout ScoutObjectData(byte[] data, string key, KeyScout counter)
+        {
+            return ScoutObjectData(data, key, counter, 0);
+        }
+
+        /**
+         * <summary>
+         * This object goes through the data and scouts out the information from the given key.
+         * This method is recursive, which is why the parameter offset exists.
+         * </summary>
+         * 
+         * <param name="data">The input array of bytes</param>
+         * <param name="key">The key</param>
+         * <param name="counter">The Scout object</param>
+         * <param name="startIndex">The starting index for the count.</param>
+         * <returns>The key scout.</returns>
+         */
+        public static KeyScout ScoutObjectData(byte[] data, string key, KeyScout counter, int startIndex)
+        {
+            MemoryStream stream = new MemoryStream(data);
+            BigBinaryReader binReader = new BigBinaryReader(stream);
+            TagBuilder currentBuilder = new TagBuilder();
+
+            binReader.BaseStream.Seek(0, SeekOrigin.Begin);
+
+            string name = key.Split('.')[0];
+            string otherKey = getKey(key.Split('.'));
+            while (binReader.BaseStream.Position != binReader.BaseStream.Length)
+            {
+                KeyScoutChild child = new KeyScoutChild();
+                currentBuilder.setDataType(binReader.ReadByte());
+                child.SetStartingIndex((int)binReader.BaseStream.Position + startIndex);
+                currentBuilder.setDataSize(binReader.ReadInt32());
+                currentBuilder.setStartingIndex(binReader.BaseStream.Position);
+                currentBuilder.setNameSize(binReader.ReadInt16());
+
+                if (currentBuilder.getNameSize() != Encoding.UTF8.GetByteCount(name))
+                {
+                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
+                    currentBuilder = new TagBuilder();
+                    continue;
+                }
+
+                byte[] nameBytes = binReader.ReadBytes(currentBuilder.getNameSize());
+                string tagName = Encoding.UTF8.GetString(nameBytes);
+                currentBuilder.setName(tagName);
+                if (tagName != name)
+                {
+                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
+                    currentBuilder = new TagBuilder();
+                    continue;
+                }
+                int binPos = (int)binReader.BaseStream.Position;
+                byte[] value = binReader.ReadBytes((int)(currentBuilder.getStartingIndex() - stream.Position) + (int)currentBuilder.getDataSize());
+                currentBuilder.setValueBytes(value);
+
+                binReader.Close();
+
+
+                if (otherKey != null)
+                {
+                    child.SetSize(currentBuilder.getDataSize());
+                    child.SetName(currentBuilder.getName());
+                    counter.AddChild(child);
+                    return ScoutObjectData(currentBuilder.getValueBytes(), otherKey, counter, binPos + startIndex);
+                }
+                child.SetSize(currentBuilder.getDataSize());
+                child.SetName(currentBuilder.getName());
+                counter.SetEnd(child);
+                return counter;
+            }
+            return null;
+        }
+
+        /**
+         * <summary>Get a list of Tags from an array of bytes. This is meant for internal use only.</summary>
+         * <param name="data">The array of bytes.</param>
+         */
+        public static List<T> GetListData<T>(byte[] data) where T : ITag
+        {
+            MemoryStream stream = new MemoryStream(data);
+            List<T> output = GetListData<T>(stream);
+            stream.Close();
+            return output;
+        }
+
+        /**
+         * <summary>Get a list of Tags from an array of bytes. This is meant for internal use only.</summary>
+         * <param name="data">The array of bytes.</param>
+         */
+        public static List<T> GetListData<T>(Stream stream) where T : ITag
+        {
+            BigBinaryReader binReader = new BigBinaryReader(stream);
+            TagBuilder currentBuilder = new TagBuilder();
+
+            binReader.BaseStream.Seek(0, SeekOrigin.Begin);
+            List<T> output = new List<T>();
+            while (binReader.BaseStream.Position != binReader.BaseStream.Length)
+            {
+                currentBuilder.setDataType(binReader.ReadByte());
+                currentBuilder.setDataSize(binReader.ReadInt32());
+                //TODO see if this is correct.
+                currentBuilder.setStartingIndex(binReader.BaseStream.Position);
+                currentBuilder.setNameSize(binReader.ReadInt16());
+
+                byte[] nameBytes = binReader.ReadBytes(currentBuilder.getNameSize());
+                String tagName = Encoding.UTF8.GetString(nameBytes);
+                currentBuilder.setName(tagName);
+
+                byte[] value = binReader.ReadBytes((int)(currentBuilder.getStartingIndex() - stream.Position) + (int)currentBuilder.getDataSize());
+                currentBuilder.setValueBytes(value);
+                output.Add((T)currentBuilder.proccess());
+            }
+            return output;
+        }
+    }
+}

--- a/ODS/Internal/ODSFile.cs
+++ b/ODS/Internal/ODSFile.cs
@@ -1,0 +1,424 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using ODS.ODSStreams;
+using ODS.Util;
+using ODS.Exceptions;
+using ODS.Tags;
+using ODS.Compression;
+
+namespace ODS.Internal
+{
+    public class ODSFile : ODSInternal
+    {
+
+        private FileInfo file;
+        private Compressor compression;
+
+        /**
+         * <summary>Construct the primary class with a file and compression type.</summary>
+         * <param name="file">The file to use.</param>
+         * <param name="compression">The compression that should be used.</param>
+         */
+        public ODSFile(FileInfo file, Compressor compression)
+        {
+            this.file = file;
+            this.compression = compression;
+        }
+
+        /**
+         * <summary>Construct the primary class with a file. The default compression type is GZIP.</summary>
+         * <param name="file">The file to use.</param>
+         */
+        public ODSFile(FileInfo file)
+        {
+            this.file = file;
+            this.compression = new GZIPCompression();
+        }
+
+        private System.IO.Stream GetCompressStream(System.IO.Stream stream)
+        {
+            return compression.GetCompressStream(stream);
+        }
+
+        private System.IO.Stream GetDecompressStream(System.IO.Stream stream)
+        {
+            return compression.GetDecompressStream(stream);
+        }
+
+        /**
+         * <summary>Grab a tag based upon an object key. This method allows you to directly get sub-objects with little overhead.</summary>
+         * <example>
+         *      GetObject("primary.firstsub.secondsub");
+         * </example>
+         * <param name="key">They key to search for.</param>
+         * <returns>The tag. This will return null if no tag with the specified key path is found or the file does not exist.</returns>
+         */
+        public ITag Get(string key)
+        {
+            if (!file.Exists)
+            {
+                return null;
+            }
+            using(FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (MemoryStream readStream = new MemoryStream())
+            {
+
+                using (Stream stream = GetDecompressStream(fs))
+                    stream.CopyTo(readStream);
+
+                readStream.Position = 0;
+
+                ITag outf = InternalUtils.getSubObjectData(readStream, key);
+
+                return outf;
+            }
+        }
+
+        /**
+         * <summary>Get all of the tags in the file.</summary>
+         * <returns>All of the tags. This returns null if the file does not exist.</returns>
+         */
+        public List<ITag> GetAll()
+        {
+            if (!file.Exists)
+            {
+                return null;
+            }
+            using (FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (MemoryStream readStream = new MemoryStream())
+            {
+
+                using (Stream stream = GetDecompressStream(fs))
+                    stream.CopyTo(readStream);
+
+                readStream.Position = 0;
+
+                List<ITag> outf = InternalUtils.GetListData<ITag>(readStream);
+
+                return outf;
+            }
+        }
+
+        /**
+         * <summary>Save tags to the file. This method will create a new file if one does not exist.
+         * This will overwrite the existing file. To append tags
+         * see #Append(ITag) and #AppendAll(List)</summary>
+         * <param name="tags">The list of tags to save.</param>
+         */
+        public void Save(List<ITag> tags)
+        {
+            using (FileStream fs = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write))
+            using (Stream stream = GetCompressStream(fs))
+            using (BigBinaryWriter bw = new BigBinaryWriter(stream))
+            {
+                foreach (ITag tag in tags)
+                {
+                    tag.WriteData(bw);
+                }
+            }
+        }
+
+        /**
+         * <summary>Append tags to the end of the file.</summary>
+         * <param name="tag">The tag to be appended.</param>
+         */
+        public void Append(ITag tag)
+        {
+            using (MemoryStream decompressedData = new MemoryStream())
+            {
+                using (FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Write))
+                {
+                    using (Stream compressStream = GetDecompressStream(fs))
+                        compressStream.CopyTo(decompressedData);
+                }
+                BigBinaryWriter bw = new BigBinaryWriter(decompressedData);
+                bw.Seek(0, SeekOrigin.End);
+                tag.WriteData(bw);
+                using (FileStream fs = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write))
+                {
+                    using (Stream stream = GetCompressStream(fs))
+                    {
+                        decompressedData.Position = 0;
+                        decompressedData.CopyTo(stream);
+                    }
+                }
+            }
+        }
+
+        /**
+         * <summary>Append a list of tags to the end of the file.</summary>
+         * <param name="tags">The list of tags.</param>
+         */
+        public void AppendAll(List<ITag> tags)
+        {
+            using (MemoryStream decompressedData = new MemoryStream())
+            {
+                using (FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Write))
+                {
+                    using (Stream compressStream = GetDecompressStream(fs))
+                        compressStream.CopyTo(decompressedData);
+                }
+                BigBinaryWriter bw = new BigBinaryWriter(decompressedData);
+                bw.Seek(0, SeekOrigin.End);
+                foreach (ITag tag in tags)
+                {
+                    tag.WriteData(bw);
+                }
+                using (FileStream fs = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write))
+                {
+                    using (Stream stream = GetCompressStream(fs))
+                    {
+                        decompressedData.Position = 0;
+                        decompressedData.CopyTo(stream);
+                    }
+                }
+            }
+        }
+
+        /**
+         * <summary>Find if a key exists within a file.</summary>
+         * <param name="key">The key to find.</param>
+         * <returns>If the key exists.</returns>
+         */
+        public bool Find(string key)
+        {
+            if (!file.Exists)
+            {
+                return false;
+            }
+            using (MemoryStream readStream = new MemoryStream())
+            {
+                using (FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (Stream stream = GetDecompressStream(fs))
+                    stream.CopyTo(readStream);
+                readStream.Position = 0;
+                return InternalUtils.findSubObjectData(readStream, key);
+            }
+        }
+
+
+        /**
+         * <summary>Remove a tag from the list.</summary>
+         * 
+         * <param name="key">The key to remove.</param>
+         * <returns>If the deletion was successfully done.</returns>
+         */
+        public bool Delete(string key)
+        {
+            if (!file.Exists)
+            {
+                return false;
+            }
+            using (MemoryStream decompressedData = new MemoryStream())
+            {
+                using (FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (Stream stream = GetDecompressStream(fs))
+                    stream.CopyTo(decompressedData);
+
+                KeyScout counter = InternalUtils.ScoutObjectData(decompressedData.ToArray(), key, new KeyScout());
+                if (counter == null)
+                {
+                    return false;
+                }
+                byte[] recompressed = InternalUtils.deleteSubObjectData(decompressedData.ToArray(), counter);
+
+                using (FileStream newFile = new FileStream(file.FullName, FileMode.Open, FileAccess.Write, FileShare.Write))
+                {
+                    newFile.SetLength(0);
+                    using (Stream compressStream = GetCompressStream(newFile))
+                        compressStream.Write(recompressed, 0, recompressed.Length);
+                }
+            }
+
+            return true;
+        }
+
+        /**
+         * <summary>Replace a key with another tag.</summary>
+         * <param name="key">The key</param>
+         * <param name="replacement">The data to replace the key</param>
+         * <returns>If the replacement was successful.</returns>
+         */
+        public bool ReplaceData(string key, ITag replacement)
+        {
+            if (!file.Exists)
+            {
+                return false;
+            }
+            using (MemoryStream decompressed = new MemoryStream())
+            {
+                using (FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read))
+                using (Stream compStream = GetDecompressStream(fs))
+                    compStream.CopyTo(decompressed);
+
+                KeyScout counter = InternalUtils.ScoutObjectData(decompressed.ToArray(), key, new KeyScout());
+                if (counter.GetEnd() == null)
+                {
+                    return false;
+                }
+
+                MemoryStream memStream = new MemoryStream();
+                BigBinaryWriter bbw = new BigBinaryWriter(memStream);
+                replacement.WriteData(bbw);
+                bbw.Close();
+
+                byte[] replaceReturn = InternalUtils.ReplaceSubObjectData(decompressed.ToArray(), counter, memStream.ToArray());
+
+                using (FileStream newFile = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write))
+                {
+                    newFile.SetLength(0);
+                    using (Stream stream = GetCompressStream(newFile))
+                        stream.Write(replaceReturn, 0, replaceReturn.Length);
+                }
+            }
+            return true;
+        }
+
+        /**
+         * <summary>
+         * This method can append, delete, and set tags.
+         * <para>A note on keys when appending: <code>ObjectOne.ObjectTwo.tagName</code> When appending data <c>tagName</c> will not be the actual tag name.
+         * The tag name written to the file is the name of the specified tag in the value parameter. Any parent objects that do not exist will be created. For example:
+         * <code>ObjectOne.ObjectTwo.NewObject.tagName</code> If in the example above <c>NewObject</c> does not exist, than the object will be created with the value tag inside
+         * of it. Please see the wiki for a more detailed explanation on this.</para>
+         * <para>When value is null, the specified key is deleted. <c>The key MUST exist or an {@link ODSException} will be thrown.</c></para>
+         * </summary>
+         * 
+         * <param name="key">
+         * The key of the tag to append, delete, or set.
+         * <para>When appending the key does not need to exist. ObjectTags that don't exist will be created automatically.</para>
+         * <para>When the key is set to "" (An empty string) than it is assumed you want to append to the parent file.</para>
+         * <para>Valid Tags:</para>
+         *  <code>
+         *  <para>ObjectOne.tagToDelete</para>
+         *  <para>ObjectOne.NewObject.tagToAppend</para>
+         *  <para>ObjectOne.tagToSet</para>
+         *  </code>
+         * </param>
+         * 
+         * <param name="value">The tag to append or replace the key with. <para>If this parameter is null than the key will be deleted.</para></param>
+         * 
+         */
+        public void Set(string key, ITag value)
+        {
+            if (value == null)
+            {
+                bool output = Delete(key);
+                if (!output)
+                    throw new ODSException("The key " + key + " does not exist!");
+                return;
+            }
+            if (key == "")
+            {
+                Save(new List<ITag>() { value });
+                return;
+            }
+            byte[] uncompressed = new byte[0];
+
+            using (FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using(Stream stream = GetDecompressStream(fs))
+            using(MemoryStream compressed = new MemoryStream())
+            {
+                
+                stream.CopyTo(compressed);
+                uncompressed = compressed.ToArray();
+            }
+
+            KeyScout counter = InternalUtils.ScoutObjectData(uncompressed, key, new KeyScout());
+            if (counter.GetEnd() == null)
+            {
+                if (counter.GetChildren().Count < 1)
+                {
+                    Append(value);
+                    return;
+                }
+                string existingKey = "";
+                foreach (KeyScoutChild child in counter.GetChildren())
+                {
+                    if (existingKey.Length != 0)
+                        existingKey += ".";
+                    existingKey += child.GetName();
+                }
+                string newKey = key.Replace(existingKey + ".", "");
+                ITag currentData;
+                if (newKey.Split('.').Length > 1)
+                {
+                    ObjectTag output = null;
+                    ObjectTag curTag = null;
+                    List<string> keys = new List<string>(newKey.Split('.'));
+                    int i = 0;
+                    foreach (string s in keys)
+                    {
+                        if (i == 0)
+                        {
+                            output = new ObjectTag(s);
+                            curTag = output;
+                        }
+                        else if (i == keys.Count - 1)
+                        {
+                            curTag.AddTag(value);
+                        }
+                        else
+                        {
+                            ObjectTag tag = new ObjectTag(s);
+                            curTag.AddTag(tag);
+                            curTag = tag;
+                        }
+                        i++;
+                    }
+                    currentData = output;
+                }
+                else
+                {
+                    currentData = value;
+                }
+                // Actually replace the data and write it to the file.
+                MemoryStream memStream = new MemoryStream();
+                BigBinaryWriter bbw = new BigBinaryWriter(memStream);
+                currentData.WriteData(bbw);
+                bbw.Close();
+                byte[] outputArray = InternalUtils.SetSubObjectData(uncompressed, counter, memStream.ToArray());
+
+                using (FileStream newFile = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write))
+                {
+                    newFile.SetLength(0);
+                    using (Stream compressStream = GetCompressStream(newFile))
+                        compressStream.Write(outputArray, 0, outputArray.Length);
+                }
+            }
+            else
+            {
+                MemoryStream memStream = new MemoryStream();
+                BigBinaryWriter bbw = new BigBinaryWriter(memStream);
+                value.WriteData(bbw);
+                bbw.Close();
+
+                byte[] replaceReturn = InternalUtils.ReplaceSubObjectData(uncompressed, counter, memStream.ToArray());
+                using (FileStream newFile = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write))
+                {
+                    newFile.SetLength(0);
+                    using (Stream compressStream = GetCompressStream(newFile))
+                        compressStream.Write(replaceReturn, 0, replaceReturn.Length);
+                }
+            }
+
+        }
+
+        public byte[] export(Compressor compressor)
+        {
+            using (FileStream fileStream = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write))
+            {
+                Stream stream = GetDecompressStream(fileStream);
+                using (MemoryStream memoryStream = new MemoryStream())
+                {
+                    using (Stream compressStream = compressor.GetCompressStream(memoryStream))
+                    {
+                        stream.CopyTo(compressStream);
+                    }
+                    return memoryStream.ToArray();
+                }
+            }
+        }
+    }
+}

--- a/ODS/Internal/ODSFile.cs
+++ b/ODS/Internal/ODSFile.cs
@@ -9,18 +9,24 @@ using ODS.Compression;
 
 namespace ODS.Internal
 {
+    /**
+     * <summary>
+     * This class handles the file storage type for ODS.
+     * <para>This class is for internal use only. Use <see cref="ObjectDataStructure"/> instead of this class.</para>
+     * </summary>
+     */
     public class ODSFile : ODSInternal
     {
 
         private FileInfo file;
-        private Compressor compression;
+        private ICompressor compression;
 
         /**
          * <summary>Construct the primary class with a file and compression type.</summary>
          * <param name="file">The file to use.</param>
          * <param name="compression">The compression that should be used.</param>
          */
-        public ODSFile(FileInfo file, Compressor compression)
+        public ODSFile(FileInfo file, ICompressor compression)
         {
             this.file = file;
             this.compression = compression;
@@ -69,7 +75,7 @@ namespace ODS.Internal
 
                 readStream.Position = 0;
 
-                ITag outf = InternalUtils.getSubObjectData(readStream, key);
+                ITag outf = InternalUtils.GetSubObjectData(readStream, key);
 
                 return outf;
             }
@@ -193,7 +199,7 @@ namespace ODS.Internal
                 using (Stream stream = GetDecompressStream(fs))
                     stream.CopyTo(readStream);
                 readStream.Position = 0;
-                return InternalUtils.findSubObjectData(readStream, key);
+                return InternalUtils.FindSubObjectData(readStream, key);
             }
         }
 
@@ -405,7 +411,7 @@ namespace ODS.Internal
 
         }
 
-        public byte[] Export(Compressor compressor)
+        public byte[] Export(ICompressor compressor)
         {
             using (FileStream fileStream = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write))
             {

--- a/ODS/Internal/ODSFile.cs
+++ b/ODS/Internal/ODSFile.cs
@@ -405,7 +405,7 @@ namespace ODS.Internal
 
         }
 
-        public byte[] export(Compressor compressor)
+        public byte[] Export(Compressor compressor)
         {
             using (FileStream fileStream = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write))
             {

--- a/ODS/Internal/ODSInternal.cs
+++ b/ODS/Internal/ODSInternal.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+using ODS.Compression;
+
+namespace ODS.Internal
+{
+    interface ODSInternal
+    {
+        ITag Get(string key);
+        List<ITag> GetAll();
+        void Save(List<ITag> tags);
+        void Append(ITag tag);
+        void AppendAll(List<ITag> tags);
+        bool Find(string key);
+        bool Delete(string key);
+        bool ReplaceData(string key, ITag replacement);
+        void Set(string key, ITag value);
+        byte[] export(Compressor compressor);
+    }
+}

--- a/ODS/Internal/ODSInternal.cs
+++ b/ODS/Internal/ODSInternal.cs
@@ -17,6 +17,6 @@ namespace ODS.Internal
         bool Delete(string key);
         bool ReplaceData(string key, ITag replacement);
         void Set(string key, ITag value);
-        byte[] export(Compressor compressor);
+        byte[] Export(Compressor compressor);
     }
 }

--- a/ODS/Internal/ODSInternal.cs
+++ b/ODS/Internal/ODSInternal.cs
@@ -6,6 +6,10 @@ using ODS.Compression;
 
 namespace ODS.Internal
 {
+    /**
+     * <summary>This is the interface that handles the internal storage types.</summary>
+     * <remarks>See <see cref="ObjectDataStructure"/> for comments on the API.</remarks>
+     */
     interface ODSInternal
     {
         ITag Get(string key);
@@ -17,6 +21,6 @@ namespace ODS.Internal
         bool Delete(string key);
         bool ReplaceData(string key, ITag replacement);
         void Set(string key, ITag value);
-        byte[] Export(Compressor compressor);
+        byte[] Export(ICompressor compressor);
     }
 }

--- a/ODS/Internal/ODSMem.cs
+++ b/ODS/Internal/ODSMem.cs
@@ -291,7 +291,7 @@ namespace ODS.Internal
 
         }
 
-        public byte[] export(Compressor compressor)
+        public byte[] Export(Compressor compressor)
         {
             using (MemoryStream mem = new MemoryStream())
             {

--- a/ODS/Internal/ODSMem.cs
+++ b/ODS/Internal/ODSMem.cs
@@ -1,0 +1,304 @@
+﻿using System;
+using System.IO;
+using System.Collections.Generic;
+using ODS.ODSStreams;
+using ODS.Util;
+using ODS.Exceptions;
+using ODS.Tags;
+using ODS.Compression;
+
+namespace ODS.Internal
+{
+    public class ODSMem : ODSInternal
+    {
+
+        private MemoryStream memStream;
+
+        /**
+         * <summary>Construct the primary class with a file and compression type.</summary>
+         * <param name="file">The file to use.</param>
+         * <param name="compression">The compression that should be used.</param>
+         */
+        public ODSMem(byte[] data, Compressor compressor)
+        {
+            using (MemoryStream mem = new MemoryStream(data))
+            {
+                using (Stream stream = compressor.GetDecompressStream(mem))
+                    stream.CopyTo(mem);
+                memStream = new MemoryStream(data);
+            }
+        }
+
+        /**
+         * <summary>Construct the primary class with a file. The default compression type is GZIP.</summary>
+         * <param name="file">The file to use.</param>
+         */
+        public ODSMem()
+        {
+            memStream = new MemoryStream();
+        }
+
+        /**
+         * <summary>Grab a tag based upon an object key. This method allows you to directly get sub-objects with little overhead.</summary>
+         * <example>
+         *      GetObject("primary.firstsub.secondsub");
+         * </example>
+         * <param name="key">They key to search for.</param>
+         * <returns>The tag. This will return null if no tag with the specified key path is found or the file does not exist.</returns>
+         */
+        public ITag Get(string key)
+        {
+
+            memStream.Position = 0;
+
+            ITag outf = InternalUtils.getSubObjectData(memStream, key);
+
+            return outf;
+        }
+
+        /**
+         * <summary>Get all of the tags in the file.</summary>
+         * <returns>All of the tags. This returns null if the file does not exist.</returns>
+         */
+        public List<ITag> GetAll()
+        {
+            
+            memStream.Position = 0;
+
+            List<ITag> outf = InternalUtils.GetListData<ITag>(memStream);
+
+            return outf;
+        }
+
+        /**
+         * <summary>Save tags to the file. This method will create a new file if one does not exist.
+         * This will overwrite the existing file. To append tags
+         * see #Append(ITag) and #AppendAll(List)</summary>
+         * <param name="tags">The list of tags to save.</param>
+         */
+        public void Save(List<ITag> tags)
+        {
+            memStream.SetLength(0);
+            memStream.Position = 0;
+            BigBinaryWriter bw = new BigBinaryWriter(memStream);
+            foreach (ITag tag in tags)
+            {
+                tag.WriteData(bw);
+            }
+            bw.Flush();
+        }
+
+        /**
+         * <summary>Append tags to the end of the file.</summary>
+         * <param name="tag">The tag to be appended.</param>
+         */
+        public void Append(ITag tag)
+        {
+            BigBinaryWriter bw = new BigBinaryWriter(memStream);
+            bw.Seek(0, SeekOrigin.End);
+            tag.WriteData(bw);
+            bw.Flush();
+        }
+
+        /**
+         * <summary>Append a list of tags to the end of the file.</summary>
+         * <param name="tags">The list of tags.</param>
+         */
+        public void AppendAll(List<ITag> tags)
+        {
+            BigBinaryWriter bw = new BigBinaryWriter(memStream);
+            bw.Seek(0, SeekOrigin.End);
+            foreach (ITag tag in tags)
+            {
+                tag.WriteData(bw);
+            }
+            bw.Flush();
+        }
+
+        /**
+         * <summary>Find if a key exists within a file.</summary>
+         * <param name="key">The key to find.</param>
+         * <returns>If the key exists.</returns>
+         */
+        public bool Find(string key)
+        {
+            memStream.Position = 0;
+            return InternalUtils.findSubObjectData(memStream, key);
+        }
+
+
+        /**
+         * <summary>Remove a tag from the list.</summary>
+         * 
+         * <param name="key">The key to remove.</param>
+         * <returns>If the deletion was successfully done.</returns>
+         */
+        public bool Delete(string key)
+        {
+            KeyScout counter = InternalUtils.ScoutObjectData(memStream.ToArray(), key, new KeyScout());
+            if (counter == null)
+            {
+                return false;
+            }
+            byte[] recompressed = InternalUtils.deleteSubObjectData(memStream.ToArray(), counter);
+
+            memStream.SetLength(0);
+            memStream.Position = 0;
+            memStream.Write(recompressed, 0, recompressed.Length);
+
+            return true;
+        }
+
+        /**
+         * <summary>Replace a key with another tag.</summary>
+         * <param name="key">The key</param>
+         * <param name="replacement">The data to replace the key</param>
+         * <returns>If the replacement was successful.</returns>
+         */
+        public bool ReplaceData(string key, ITag replacement)
+        {
+            KeyScout counter = InternalUtils.ScoutObjectData(memStream.ToArray(), key, new KeyScout());
+            if (counter.GetEnd() == null)
+            {
+                return false;
+            }
+
+            MemoryStream tempStream = new MemoryStream();
+            BigBinaryWriter bbw = new BigBinaryWriter(tempStream);
+            replacement.WriteData(bbw);
+            bbw.Close();
+
+            byte[] replaceReturn = InternalUtils.ReplaceSubObjectData(memStream.ToArray(), counter, tempStream.ToArray());
+            memStream.SetLength(0);
+            memStream.Position = 0;
+            memStream.Write(replaceReturn, 0, replaceReturn.Length);
+            return true;
+        }
+
+        /**
+         * <summary>
+         * This method can append, delete, and set tags.
+         * <para>A note on keys when appending: <code>ObjectOne.ObjectTwo.tagName</code> When appending data <c>tagName</c> will not be the actual tag name.
+         * The tag name written to the file is the name of the specified tag in the value parameter. Any parent objects that do not exist will be created. For example:
+         * <code>ObjectOne.ObjectTwo.NewObject.tagName</code> If in the example above <c>NewObject</c> does not exist, than the object will be created with the value tag inside
+         * of it. Please see the wiki for a more detailed explanation on this.</para>
+         * <para>When value is null, the specified key is deleted. <c>The key MUST exist or an {@link ODSException} will be thrown.</c></para>
+         * </summary>
+         * 
+         * <param name="key">
+         * The key of the tag to append, delete, or set.
+         * <para>When appending the key does not need to exist. ObjectTags that don't exist will be created automatically.</para>
+         * <para>When the key is set to "" (An empty string) than it is assumed you want to append to the parent file.</para>
+         * <para>Valid Tags:</para>
+         *  <code>
+         *  <para>ObjectOne.tagToDelete</para>
+         *  <para>ObjectOne.NewObject.tagToAppend</para>
+         *  <para>ObjectOne.tagToSet</para>
+         *  </code>
+         * </param>
+         * 
+         * <param name="value">The tag to append or replace the key with. <para>If this parameter is null than the key will be deleted.</para></param>
+         * 
+         */
+        public void Set(string key, ITag value)
+        {
+            if (value == null)
+            {
+                bool output = Delete(key);
+                if (!output)
+                    throw new ODSException("The key " + key + " does not exist!");
+                return;
+            }
+            if (key == "")
+            {
+                Save(new List<ITag>() { value });
+                return;
+            }
+            byte[] uncompressed = memStream.ToArray();
+
+            KeyScout counter = InternalUtils.ScoutObjectData(uncompressed, key, new KeyScout());
+            if (counter.GetEnd() == null)
+            {
+                if (counter.GetChildren().Count < 1)
+                {
+                    Append(value);
+                    return;
+                }
+                string existingKey = "";
+                foreach (KeyScoutChild child in counter.GetChildren())
+                {
+                    if (existingKey.Length != 0)
+                        existingKey += ".";
+                    existingKey += child.GetName();
+                }
+                string newKey = key.Replace(existingKey + ".", "");
+                ITag currentData;
+                if (newKey.Split('.').Length > 1)
+                {
+                    ObjectTag output = null;
+                    ObjectTag curTag = null;
+                    List<string> keys = new List<string>(newKey.Split('.'));
+                    int i = 0;
+                    foreach (string s in keys)
+                    {
+                        if (i == 0)
+                        {
+                            output = new ObjectTag(s);
+                            curTag = output;
+                        }
+                        else if (i == keys.Count - 1)
+                        {
+                            curTag.AddTag(value);
+                        }
+                        else
+                        {
+                            ObjectTag tag = new ObjectTag(s);
+                            curTag.AddTag(tag);
+                            curTag = tag;
+                        }
+                        i++;
+                    }
+                    currentData = output;
+                }
+                else
+                {
+                    currentData = value;
+                }
+                // Actually replace the data and write it to the file.
+                MemoryStream tempStream = new MemoryStream();
+                BigBinaryWriter bbw = new BigBinaryWriter(tempStream);
+                currentData.WriteData(bbw);
+                bbw.Close();
+                byte[] outputArray = InternalUtils.SetSubObjectData(uncompressed, counter, tempStream.ToArray());
+
+                memStream.SetLength(0);
+                memStream.Position = 0;
+                memStream.Write(outputArray, 0, outputArray.Length);
+            }
+            else
+            {
+                MemoryStream tempStream = new MemoryStream();
+                BigBinaryWriter bbw = new BigBinaryWriter(tempStream);
+                value.WriteData(bbw);
+                bbw.Close();
+
+                byte[] replaceReturn = InternalUtils.ReplaceSubObjectData(uncompressed, counter, tempStream.ToArray());
+
+                memStream.SetLength(0);
+                memStream.Position = 0;
+                memStream.Write(replaceReturn, 0, replaceReturn.Length);
+            }
+
+        }
+
+        public byte[] export(Compressor compressor)
+        {
+            using (MemoryStream mem = new MemoryStream())
+            {
+                using (Stream compressStream = compressor.GetCompressStream(mem))
+                    memStream.CopyTo(compressStream);
+                return mem.ToArray();
+            }
+        }
+    }
+}

--- a/ODS/Internal/ODSMem.cs
+++ b/ODS/Internal/ODSMem.cs
@@ -9,6 +9,11 @@ using ODS.Compression;
 
 namespace ODS.Internal
 {
+    /**
+     * <summary>This class handles the Memory storage type of ODS.
+     * <para>This is for internal use only. Use <see cref="ObjectDataStructure"/> instead of this class.</para>
+     * </summary>
+     */
     public class ODSMem : ODSInternal
     {
 
@@ -19,7 +24,7 @@ namespace ODS.Internal
          * <param name="file">The file to use.</param>
          * <param name="compression">The compression that should be used.</param>
          */
-        public ODSMem(byte[] data, Compressor compressor)
+        public ODSMem(byte[] data, ICompressor compressor)
         {
             using (MemoryStream mem = new MemoryStream(data))
             {
@@ -51,7 +56,7 @@ namespace ODS.Internal
 
             memStream.Position = 0;
 
-            ITag outf = InternalUtils.getSubObjectData(memStream, key);
+            ITag outf = InternalUtils.GetSubObjectData(memStream, key);
 
             return outf;
         }
@@ -123,7 +128,7 @@ namespace ODS.Internal
         public bool Find(string key)
         {
             memStream.Position = 0;
-            return InternalUtils.findSubObjectData(memStream, key);
+            return InternalUtils.FindSubObjectData(memStream, key);
         }
 
 
@@ -291,7 +296,7 @@ namespace ODS.Internal
 
         }
 
-        public byte[] Export(Compressor compressor)
+        public byte[] Export(ICompressor compressor)
         {
             using (MemoryStream mem = new MemoryStream())
             {

--- a/ODS/ODS.csproj
+++ b/ODS/ODS.csproj
@@ -10,7 +10,7 @@
     <Description>Object Data Structure is a fast byte based file format designed for video games.</Description>
     <RepositoryUrl>https://github.com/ryandw11/ODSSharp</RepositoryUrl>
     <PackageTags>ODS, File Format, File, Storage, Fast, Games</PackageTags>
-    <Version>1.0.1</Version>
+    <Version>1.0.2</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/ODS/ODSStreams/BigBinaryReader.cs
+++ b/ODS/ODSStreams/BigBinaryReader.cs
@@ -3,14 +3,14 @@ using System.Collections.Generic;
 using System.Text;
 using System.IO;
 
-namespace ODS.Stream
+namespace ODS.ODSStreams
 {
     /**
      * <summary>This is similar to BinaryReader but in Big Endian format, which is what ODS uses.</summary>
      */
     public class BigBinaryReader : BinaryReader
     {
-        public BigBinaryReader(System.IO.Stream stream) : base(stream) { }
+        public BigBinaryReader(Stream stream) : base(stream) { }
 
         public override int ReadInt32()
         {

--- a/ODS/ODSStreams/BigBinaryWriter.cs
+++ b/ODS/ODSStreams/BigBinaryWriter.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.IO;
 
-namespace ODS.Stream
+namespace ODS.ODSStreams
 {
     /**
      * <summary>This is similar to BinaryWriter, but it writes in Big Endian format, which is what ODS uses.</summary>

--- a/ODS/ODSStreams/ByteConverter.cs
+++ b/ODS/ODSStreams/ByteConverter.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace ODS.Stream
+namespace ODS.ODSStreams
 {
     /**
      * <summary>This utility class swaps the Endianess of the formats.</summary>

--- a/ODS/ODSUtil.cs
+++ b/ODS/ODSUtil.cs
@@ -15,6 +15,8 @@ namespace ODS
         internal static bool ignoreInvalidCustomTags = false; 
         private static List<ITag> customTags = new List<ITag>();
 
+        private ODSUtil() { }
+
         /**
          * <summary>Wrap an object to a tag. The name is not set by this method. This method
          * cannot wrap Lists or Dictionaries. Objects are automatically serialized.</summary>
@@ -97,8 +99,8 @@ namespace ODS
          * <summary>Wrap a list into a list tag.</summary>
          * <param name="name">The name of the list tag.</param>
          * <param name="list">The list to turn into a list tag. The list can only contain objects that
-         * can be converted into tags. The contents of the list are atuomatically wrapped. Note: this list cannot
-         * contain Objects, other Lists, or Dictionaries.</param>
+         * can be converted into tags. The contents of the list are atuomatically wrapped. <para>Note: this list cannot
+         * contain Objects, other Lists, or Dictionaries.</para></param>
          * <typeparam name="T">The data type of the list.</typeparam>
          * <returns>The wrapped ListTag</returns>
          */

--- a/ODS/ObjectDataStructure.cs
+++ b/ODS/ObjectDataStructure.cs
@@ -186,6 +186,10 @@ namespace ODS
             odsInternal.Set(key, value);
         }
 
-        
+        public byte[] Export(Compressor compressor)
+        {
+            return odsInternal.Export(compressor);
+        }
+
     }
 }

--- a/ODS/ObjectDataStructure.cs
+++ b/ODS/ObjectDataStructure.cs
@@ -1,76 +1,89 @@
-﻿using System;
-using System.Text;
-using System.IO;
+﻿using System.IO;
 using System.Collections.Generic;
-using ODS.Stream;
-using ODS.Util;
-using ODS.Exceptions;
-using ODS.Tags;
 using ODS.Compression;
+using ODS.Internal;
 
 namespace ODS
 {
     /**
-     * <summary>Primary class of the ObjectDataStructure library.</summary>
+     * <summary>
+     * Primary class of the ObjectDataStructure library.
+     * <para>ObjectDataStructure has two storage types: File and Memory. File reads from a file while memory deals with
+     * an array (or buffer) of bytes. This class deals with both types. The type is dependent on the constructor.</para>
+     * <para>Most methods in ODS use what is called a key to reference objects within the file/buffer. A key allows you to grab specific
+     * information within the file/buffer. For example: If you wanted a specific string inside of an object with lots of information,
+     * you can get that specific string without any other data. If you have an object named Car and you wanted to get a string tag named
+     * owner from the inside the object, then the key for that would be:</para>
+     * <code>
+     *  Car.owner
+     * </code>
+     * <para>Let's say that the owner is an object called 'Owner' and you want to get the age of the owner, you could do:</para>
+     * <code>
+     * Car.Owner.age
+     * </code>
+     * <para>You can obtain any tag using the key system, including ObjectTags. So the key `Car.Owner` would be valid.</para>
+     * </summary>
+     * 
+     * <remarks>For exact information on the methods depending on storage type (viz. File or Memory) please visit the respective internal classes.</remarks>
      */
     public class ObjectDataStructure
     {
-        private FileInfo file;
-        private Compressor compression;
+        private ODSInternal odsInternal;
 
         /**
-         * <summary>Construct the primary class with a file and compression type.</summary>
+         * <summary>Create ODS using the file storage type. Data will be written to and read from a file.</summary>
          * <param name="file">The file to use.</param>
          * <param name="compression">The compression that should be used.</param>
          */
         public ObjectDataStructure(FileInfo file, Compressor compression)
         {
-            this.file = file;
-            this.compression = compression;
+            this.odsInternal = new ODSFile(file, compression);
         }
 
         /**
-         * <summary>Construct the primary class with a file. The default compression type is GZIP.</summary>
+         * <summary>Create ODS using the file storage type. Data will be written to and read from a file.</summary>
          * <param name="file">The file to use.</param>
          */
         public ObjectDataStructure(FileInfo file)
         {
-            this.file = file;
-            this.compression = new GZIPCompression();
+            this.odsInternal = new ODSFile(file);
         }
 
-        private byte[] compress(byte[] data)
+        /**
+         * <summary>Create ODS using the memory storage type. Data will be written to and read from a memory stream.</summary>
+         * <param name="data">Pre-existing data that should be inserted into the memory stream.</param>
+         * <param name="compressor">The compression format the data uses.</param>
+         */
+        public ObjectDataStructure(byte[] data, Compressor compressor)
         {
-            return compression.Compress(data);
+            this.odsInternal = new ODSMem(data, compressor);
         }
 
-        private byte[] decompress(byte[] data)
+        /**
+         * <summary>Create ODS using the memory storage type. Data will be written to and read from a memory stream.</summary>
+         */
+        public ObjectDataStructure()
         {
-            return compression.Decompress(data);
+            this.odsInternal = new ODSMem();
         }
+
+        /*
+         * TODO :: Finish updaing the comments. 
+         * 
+         * 
+         */
 
         /**
          * <summary>Grab a tag based upon an object key. This method allows you to directly get sub-objects with little overhead.</summary>
          * <example>
-         *      GetObject("primary.firstsub.secondsub");
+         *      Get("primary.firstsub.secondsub");
          * </example>
          * <param name="key">They key to search for.</param>
          * <returns>The tag. This will return null if no tag with the specified key path is found or the file does not exist.</returns>
          */
         public ITag Get(string key)
         {
-            if (!file.Exists)
-            {
-                return null;
-            }
-            FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
-            MemoryStream compressed = new MemoryStream();
-            fs.CopyTo(compressed);
-            byte[] uncompressed = decompress(compressed.ToArray());
-
-            ITag outf = getSubObjectData(uncompressed, key);
-            fs.Close();
-            return outf;
+            return odsInternal.Get(key);
         }
 
         /**
@@ -79,19 +92,7 @@ namespace ODS
          */
         public List<ITag> GetAll()
         {
-            if (!file.Exists)
-            {
-                return null;
-            }
-            FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
-            MemoryStream compressed = new MemoryStream();
-            fs.CopyTo(compressed);
-            byte[] uncompressed = decompress(compressed.ToArray());
-            compressed.Close();
-
-            List<ITag> outf = GetListData<ITag>(uncompressed);
-            fs.Close();
-            return outf;
+            return odsInternal.GetAll();
         }
 
         /**
@@ -102,18 +103,7 @@ namespace ODS
          */
         public void Save(List<ITag> tags)
         {
-            FileStream fs = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write);
-            MemoryStream ms = new MemoryStream();
-            BigBinaryWriter bw = new BigBinaryWriter(ms);
-            foreach (ITag tag in tags)
-            {
-                tag.WriteData(bw);
-            }
-            bw.Close();
-            byte[] data = compress(ms.ToArray());
-            fs.Write(data, 0, data.Length);
-            ms.Close();
-            fs.Close();
+            odsInternal.Save(tags);
         }
 
         /**
@@ -122,25 +112,7 @@ namespace ODS
          */
         public void Append(ITag tag)
         {
-            FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Write);
-            MemoryStream compressed = new MemoryStream();
-            fs.CopyTo(compressed);
-            MemoryStream ms = new MemoryStream();
-            byte[] decompressed = decompress(compressed.ToArray());
-            ms.Write(decompressed, 0, decompressed.Length);
-            BigBinaryWriter bw = new BigBinaryWriter(ms);
-            fs.Close();
-
-            ms.Seek(0, SeekOrigin.End);
-            tag.WriteData(bw);
-            bw.Close();
-
-            FileStream appendFile = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write);
-            byte[] data = compress(ms.ToArray());
-            appendFile.SetLength(0);
-            appendFile.Write(data, 0, data.Length);
-            ms.Close();
-            appendFile.Close();
+            odsInternal.Append(tag);
         }
 
         /**
@@ -149,28 +121,7 @@ namespace ODS
          */
         public void AppendAll(List<ITag> tags)
         {
-            FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Write);
-            MemoryStream compressed = new MemoryStream();
-            fs.CopyTo(compressed);
-            MemoryStream ms = new MemoryStream();
-            byte[] decompressed = decompress(compressed.ToArray());
-            ms.Write(decompressed, 0, decompressed.Length);
-            BigBinaryWriter bw = new BigBinaryWriter(ms);
-            fs.Close();
-
-            ms.Seek(0, SeekOrigin.End);
-            foreach (ITag tag in tags)
-            {
-                tag.WriteData(bw);
-            }
-            bw.Close();
-
-            FileStream appendFile = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write);
-            byte[] data = compress(ms.ToArray());
-            appendFile.SetLength(0);
-            appendFile.Write(data, 0, data.Length);
-            ms.Close();
-            appendFile.Close();
+            odsInternal.AppendAll(tags);
         }
 
         /**
@@ -180,22 +131,8 @@ namespace ODS
          */
         public bool Find(string key)
         {
-            if (!file.Exists)
-            {
-                return false;
-            }
-            FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
-            MemoryStream compressed = new MemoryStream();
-            fs.CopyTo(compressed);
-            byte[] uncompressed = decompress(compressed.ToArray()); 
-            fs.Close();
-            return findSubObjectData(uncompressed, key); ;
+            return odsInternal.Find(key);
         }
-
-        // TODO stuff
-
-
-
 
         /**
          * <summary>Remove a tag from the list.</summary>
@@ -205,28 +142,7 @@ namespace ODS
          */
         public bool Delete(string key)
         {
-            if (!file.Exists)
-            {
-                return false;
-            }
-            FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
-            MemoryStream compressed = new MemoryStream();
-            fs.CopyTo(compressed);
-            byte[] uncompressed = decompress(compressed.ToArray());
-            fs.Close();
-
-            KeyScout counter = ScoutObjectData(uncompressed, key, new KeyScout());
-            if (counter == null)
-            {
-                return false;
-            }
-            byte[] recompressed = compress(deleteSubObjectData(uncompressed, counter));
-
-            FileStream newFile = new FileStream(file.FullName, FileMode.Open, FileAccess.Write, FileShare.Write);
-            newFile.SetLength(0);
-            newFile.Write(recompressed, 0, recompressed.Length);
-            newFile.Close();
-            return true;
+            return odsInternal.Delete(key);
         }
 
         /**
@@ -237,37 +153,7 @@ namespace ODS
          */
         public bool ReplaceData(string key, ITag replacement)
         {
-            if (!file.Exists)
-            {
-                return false;
-            }
-
-            FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
-            MemoryStream compressed = new MemoryStream();
-            fs.CopyTo(compressed);
-            byte[] uncompressed = decompress(compressed.ToArray());
-            fs.Close();
-
-            KeyScout counter = ScoutObjectData(uncompressed, key, new KeyScout());
-            if (counter.GetEnd() == null)
-            {
-                return false;
-            }
-
-            MemoryStream memStream = new MemoryStream();
-            BigBinaryWriter bbw = new BigBinaryWriter(memStream);
-            replacement.WriteData(bbw);
-            bbw.Close();
-
-            byte[] replaceReturn = ReplaceSubObjectData(uncompressed, counter, memStream.ToArray());
-
-            FileStream newFile = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write);
-            newFile.SetLength(0);
-            byte[] recompressed = compress(replaceReturn);
-            newFile.Write(recompressed, 0, recompressed.Length);
-
-            newFile.Close();
-            return true;
+            return odsInternal.ReplaceData(key, replacement);
         }
 
         /**
@@ -297,467 +183,9 @@ namespace ODS
          */
         public void Set(string key, ITag value)
         {
-            if(value == null)
-            {
-                bool output = Delete(key);
-                if (!output)
-                    throw new ODSException("The key " + key + " does not exist!");
-                return;
-            }
-            if(key == "")
-            {
-                Save(new List<ITag>(){ value });
-                return;
-            }
-            FileStream fs = new FileStream(file.FullName, FileMode.Open, FileAccess.Read, FileShare.Read);
-            MemoryStream compressed = new MemoryStream();
-            fs.CopyTo(compressed);
-            byte[] uncompressed = decompress(compressed.ToArray());
-            fs.Close();
-
-            KeyScout counter = ScoutObjectData(uncompressed, key, new KeyScout());
-            if (counter.GetEnd() == null)
-            {
-                if(counter.GetChildren().Count < 1)
-                {
-                    Append(value);
-                    return;
-                }
-                string existingKey = "";
-                foreach (KeyScoutChild child in counter.GetChildren())
-                {
-                    if (existingKey.Length != 0)
-                        existingKey += ".";
-                    existingKey += child.GetName();
-                }
-                string newKey = key.Replace(existingKey + ".", "");
-                ITag currentData;
-                if(newKey.Split('.').Length > 1)
-                {
-                    ObjectTag output = null;
-                    ObjectTag curTag = null;
-                    List<string> keys = new List<string>(newKey.Split('.'));
-                    int i = 0;
-                    foreach (string s in keys){
-                        if(i == 0)
-                        {
-                            output = new ObjectTag(s);
-                            curTag = output;
-                        }else if(i == keys.Count - 1)
-                        {
-                            curTag.AddTag(value);
-                        }
-                        else
-                        {
-                            ObjectTag tag = new ObjectTag(s);
-                            curTag.AddTag(tag);
-                            curTag = tag;
-                        }
-                        i++;
-                    }
-                    currentData = output;
-                }
-                else
-                {
-                    currentData = value;
-                }
-                // Actually replace the data and write it to the file.
-                MemoryStream memStream = new MemoryStream();
-                BigBinaryWriter bbw = new BigBinaryWriter(memStream);
-                currentData.WriteData(bbw);
-                bbw.Close();
-                byte[] outputArray = SetSubObjectData(uncompressed, counter, memStream.ToArray());
-
-                FileStream newFile = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write);
-                newFile.SetLength(0);
-                byte[] recompressed = compress(outputArray);
-                newFile.Write(recompressed, 0, recompressed.Length);
-                newFile.Close();
-            }
-            else
-            {
-                MemoryStream memStream = new MemoryStream();
-                BigBinaryWriter bbw = new BigBinaryWriter(memStream);
-                value.WriteData(bbw);
-                bbw.Close();
-
-                byte[] replaceReturn = ReplaceSubObjectData(uncompressed, counter, memStream.ToArray());
-                FileStream newFile = new FileStream(file.FullName, FileMode.Create, FileAccess.Write, FileShare.Write);
-                newFile.SetLength(0);
-                byte[] recompressed = compress(replaceReturn);
-                newFile.Write(recompressed, 0, recompressed.Length);
-                newFile.Close();
-            }
-
+            odsInternal.Set(key, value);
         }
 
-        /**
-         * Used to get a tag from the file.
-         */
-        private ITag getSubData(MemoryStream stream, string name)
-        {
-            BigBinaryReader binReader = new BigBinaryReader(stream);
-            TagBuilder currentBuilder = new TagBuilder();
-
-            binReader.BaseStream.Seek(0, SeekOrigin.Begin);
-
-            while (binReader.BaseStream.Position != binReader.BaseStream.Length)
-            {
-                currentBuilder.setDataType(binReader.ReadByte());
-                currentBuilder.setDataSize(binReader.ReadInt32());
-                //TODO see if this is correct.
-                currentBuilder.setStartingIndex(binReader.BaseStream.Position);
-                currentBuilder.setNameSize(binReader.ReadInt16());
-
-                if (currentBuilder.getNameSize() != Encoding.UTF8.GetByteCount(name))
-                {
-                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
-                    currentBuilder = new TagBuilder();
-                    continue;
-                }
-
-                byte[] nameBytes = binReader.ReadBytes(currentBuilder.getNameSize());
-                String tagName = Encoding.UTF8.GetString(nameBytes);
-                currentBuilder.setName(tagName);
-                if (tagName != name)
-                {
-                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
-                    currentBuilder = new TagBuilder();
-                    continue;
-                }
-
-                byte[] value = binReader.ReadBytes((int) (currentBuilder.getStartingIndex() - stream.Position) + (int) currentBuilder.getDataSize());
-                currentBuilder.setValueBytes(value);
-                binReader.Close();
-                return currentBuilder.proccess();
-            }
-            binReader.Close();
-            return null;
-        }
-
-        /**
-         * Used to get a tag from the file using the key system.
-         */
-        private ITag getSubObjectData(byte[] data, string key)
-        {
-            MemoryStream stream = new MemoryStream(data);
-            BigBinaryReader binReader = new BigBinaryReader(stream);
-            TagBuilder currentBuilder = new TagBuilder();
-
-            binReader.BaseStream.Seek(0, SeekOrigin.Begin);
-
-            string name = key.Split('.')[0];
-            string otherKey = getKey(key.Split('.'));
-
-
-            while (binReader.BaseStream.Position != binReader.BaseStream.Length)
-            {
-                currentBuilder.setDataType(binReader.ReadByte());
-                currentBuilder.setDataSize(binReader.ReadInt32());
-                //TODO see if this is correct.
-                currentBuilder.setStartingIndex(binReader.BaseStream.Position);
-                currentBuilder.setNameSize(binReader.ReadInt16());
-
-                if (currentBuilder.getNameSize() != Encoding.UTF8.GetByteCount(name))
-                {
-                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
-                    currentBuilder = new TagBuilder();
-                    continue;
-                }
-
-                byte[] nameBytes = binReader.ReadBytes(currentBuilder.getNameSize());
-                String tagName = Encoding.UTF8.GetString(nameBytes);
-                currentBuilder.setName(tagName);
-                if (tagName != name)
-                {
-                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
-                    currentBuilder = new TagBuilder();
-                    continue;
-                }
-
-                byte[] value = binReader.ReadBytes((int)(currentBuilder.getStartingIndex() - stream.Position) + (int)currentBuilder.getDataSize());
-                currentBuilder.setValueBytes(value);
-                binReader.Close();
-
-                if (otherKey != null)
-                    return getSubObjectData(currentBuilder.getValueBytes(), otherKey);
-                return currentBuilder.proccess();
-            }
-            binReader.Close();
-            return null;
-        }
-
-        private string getKey(string[] s)
-        {
-            List<string> list = new List<string>(s);
-            list.Remove(list[0]);
-            if (list.Count == 1) return list[0];
-            if (list.Count < 1) return null;
-
-            return string.Join(".", list);
-        }
-
-        /**
-         * This is used to find the tags using the key system.
-         */
-        private bool findSubObjectData(byte[] data, string key)
-        {
-            MemoryStream stream = new MemoryStream(data);
-            BigBinaryReader binReader = new BigBinaryReader(stream);
-            TagBuilder currentBuilder = new TagBuilder();
-
-            binReader.BaseStream.Seek(0, SeekOrigin.Begin);
-
-            string name = key.Split('.')[0];
-            string otherKey = getKey(key.Split('.'));
-
-
-            while (binReader.BaseStream.Position != binReader.BaseStream.Length)
-            {
-                currentBuilder.setDataType(binReader.ReadByte());
-                currentBuilder.setDataSize(binReader.ReadInt32());
-                //TODO see if this is correct.
-                currentBuilder.setStartingIndex(binReader.BaseStream.Position);
-                currentBuilder.setNameSize(binReader.ReadInt16());
-
-                if (currentBuilder.getNameSize() != Encoding.UTF8.GetByteCount(name))
-                {
-                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
-                    currentBuilder = new TagBuilder();
-                    continue;
-                }
-
-                byte[] nameBytes = binReader.ReadBytes(currentBuilder.getNameSize());
-                String tagName = Encoding.UTF8.GetString(nameBytes);
-                currentBuilder.setName(tagName);
-                if (tagName != name)
-                {
-                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
-                    currentBuilder = new TagBuilder();
-                    continue;
-                }
-
-                byte[] value = binReader.ReadBytes((int)(currentBuilder.getStartingIndex() - stream.Position) + (int)currentBuilder.getDataSize());
-                currentBuilder.setValueBytes(value);
-                binReader.Close();
-
-                if (otherKey != null)
-                    return findSubObjectData(currentBuilder.getValueBytes(), otherKey);
-                return true;
-            }
-            binReader.Close();
-            return false;
-        }
-
-
-        /**
-         * This is used to delete tags from the list. This does not support key format.
-         */
-        private byte[] deleteSubObjectData(byte[] data, KeyScout counter)
-        {
-            counter.RemoveAmount(counter.GetEnd().GetSize() + 5);
-
-            KeyScoutChild end = counter.GetEnd();
-
-            byte[] array1 = new byte[data.Length - (5 + end.GetSize())];
-            Array.Copy(data, 0, array1, 0, (end.GetStartingIndex() - 1));
-            Array.Copy(data, end.GetStartingIndex() + 4 + end.GetSize(),
-                array1, end.GetStartingIndex() - 1,
-                data.Length - (end.GetStartingIndex() + 4 + end.GetSize()));
-
-            foreach (KeyScoutChild child in counter.GetChildren())
-            {
-                int index = child.GetStartingIndex();
-                int size = child.GetSize();
-                array1[index] = (byte)(size >> 24);
-                array1[index + 1] = (byte)(size >> 16);
-                array1[index + 2] = (byte)(size >> 8);
-                array1[index + 3] = (byte) size;
-            }
-
-            return array1;
-        }
-
-        /**
-         * <summary>
-         * Replace a tag with another tag.
-         * </summary>
-         * <param name="data">The input array of bytes</param>
-         * <param name="counter">The scout object</param>
-         * <param name="dataToReplace">The bytes of the replacement data.</param>
-         * <returns>The output bytes.</returns>
-         */
-        private byte[] ReplaceSubObjectData(byte[] data, KeyScout counter, byte[] dataToReplace)
-        {
-            counter.RemoveAmount(counter.GetEnd().GetSize() + 5);
-            counter.AddAmount(dataToReplace.Length);
-
-            KeyScoutChild end = counter.GetEnd();
-
-
-            byte[] array1 = new byte[data.Length - (5 + end.GetSize()) + dataToReplace.Length];
-            //Copy all of the information before the removed data.
-            Array.Copy(data, 0, array1, 0, (end.GetStartingIndex() - 1));
-            Array.Copy(dataToReplace, 0, array1, end.GetStartingIndex() - 1, dataToReplace.Length);
-            // copy all of the information after the removed data.
-            Array.Copy(data, end.GetStartingIndex() + 4 + end.GetSize(),
-                    array1, end.GetStartingIndex() - 1 + dataToReplace.Length,
-                    data.Length - (end.GetStartingIndex() + 4 + end.GetSize()));
-
-            foreach (KeyScoutChild child in counter.GetChildren())
-            {
-                int index = child.GetStartingIndex();
-                int size = child.GetSize();
-                array1[index] = (byte)(size >> 24);
-                array1[index + 1] = (byte)(size >> 16);
-                array1[index + 2] = (byte)(size >> 8);
-                array1[index + 3] = (byte)(size);
-            }
-
-            return array1;
-        }
-
-        private byte[] SetSubObjectData(byte[] data, KeyScout counter, byte[] dataToReplace)
-        {
-            KeyScoutChild child = counter.GetChildren()[counter.GetChildren().Count - 1];
-
-
-            byte[] array1 = new byte[data.Length + dataToReplace.Length];
-            Array.Copy(data, 0, array1, 0, child.GetStartingIndex() + 4 + child.GetSize());
-            Array.Copy(dataToReplace, 0, array1, child.GetStartingIndex() + 4 + child.GetSize(), dataToReplace.Length);
-            Array.Copy(data, (child.GetStartingIndex() + 4 + child.GetSize()), array1, (child.GetStartingIndex() + 4 + child.GetSize()) + dataToReplace.Length,
-                    data.Length - (child.GetStartingIndex() + 4 + child.GetSize()));
-
-            counter.AddAmount(dataToReplace.Length);
-
-            foreach (KeyScoutChild childs in counter.GetChildren())
-            {
-                int index = childs.GetStartingIndex();
-                int size = childs.GetSize();
-                array1[index] = (byte)(size >> 24);
-                array1[index + 1] = (byte)(size >> 16);
-                array1[index + 2] = (byte)(size >> 8);
-                array1[index + 3] = (byte)(size);
-            }
-
-            return array1;
-        }
-
-        /**
-         * <summary>
-         * This object goes through the data and scouts out the information from the given key.
-         * This method is recursive, which is why the parameter offset exists.
-         * </summary>
-         * 
-         * <param name="data">The input array of bytes</param>
-         * <param name="key">The key</param>
-         * <param name="counter">The Scout object</param>
-         * <returns>The key scout.</returns>
-         */
-        private KeyScout ScoutObjectData(byte[] data, string key, KeyScout counter)
-        {
-            return ScoutObjectData(data, key, counter, 0);
-        }
-
-        /**
-         * <summary>
-         * This object goes through the data and scouts out the information from the given key.
-         * This method is recursive, which is why the parameter offset exists.
-         * </summary>
-         * 
-         * <param name="data">The input array of bytes</param>
-         * <param name="key">The key</param>
-         * <param name="counter">The Scout object</param>
-         * <param name="startIndex">The starting index for the count.</param>
-         * <returns>The key scout.</returns>
-         */
-        private KeyScout ScoutObjectData(byte[] data, string key, KeyScout counter, int startIndex)
-        {
-            MemoryStream stream = new MemoryStream(data);
-            BigBinaryReader binReader = new BigBinaryReader(stream);
-            TagBuilder currentBuilder = new TagBuilder();
-
-            binReader.BaseStream.Seek(0, SeekOrigin.Begin);
-
-            string name = key.Split('.')[0];
-            string otherKey = getKey(key.Split('.'));
-            while(binReader.BaseStream.Position != binReader.BaseStream.Length)
-            {
-                KeyScoutChild child = new KeyScoutChild();
-                currentBuilder.setDataType(binReader.ReadByte());
-                child.SetStartingIndex((int) binReader.BaseStream.Position + startIndex);
-                currentBuilder.setDataSize(binReader.ReadInt32());
-                currentBuilder.setStartingIndex(binReader.BaseStream.Position);
-                currentBuilder.setNameSize(binReader.ReadInt16());
-
-                if (currentBuilder.getNameSize() != Encoding.UTF8.GetByteCount(name))
-                {
-                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
-                    currentBuilder = new TagBuilder();
-                    continue;
-                }
-
-                byte[] nameBytes = binReader.ReadBytes(currentBuilder.getNameSize());
-                string tagName = Encoding.UTF8.GetString(nameBytes);
-                currentBuilder.setName(tagName);
-                if (tagName != name)
-                {
-                    binReader.BaseStream.Seek((currentBuilder.getStartingIndex() - stream.Position) + currentBuilder.getDataSize(), SeekOrigin.Current);
-                    currentBuilder = new TagBuilder();
-                    continue;
-                }
-                int binPos = (int)binReader.BaseStream.Position;
-                byte[] value = binReader.ReadBytes((int)(currentBuilder.getStartingIndex() - stream.Position) + (int)currentBuilder.getDataSize());
-                currentBuilder.setValueBytes(value);
-                
-                binReader.Close();
-
-
-                if (otherKey != null)
-                {
-                    child.SetSize(currentBuilder.getDataSize());
-                    child.SetName(currentBuilder.getName());
-                    counter.AddChild(child);
-                    return ScoutObjectData(currentBuilder.getValueBytes(), otherKey, counter, binPos + startIndex);
-                }
-                child.SetSize(currentBuilder.getDataSize());
-                child.SetName(currentBuilder.getName());
-                counter.SetEnd(child);
-                return counter;
-            }
-            return counter;
-        }
-
-        /**
-         * <summary>Get a list of Tags from an array of bytes. This is meant for internal use only.</summary>
-         * <param name="data">The array of bytes.</param>
-         */
-        public static List<T> GetListData<T>(byte[] data) where T : ITag
-        {
-            MemoryStream stream = new MemoryStream(data);
-            BigBinaryReader binReader = new BigBinaryReader(stream);
-            TagBuilder currentBuilder = new TagBuilder();
-
-            binReader.BaseStream.Seek(0, SeekOrigin.Begin);
-            List<T> output = new List<T>();
-            while (binReader.BaseStream.Position != binReader.BaseStream.Length)
-            {
-                currentBuilder.setDataType(binReader.ReadByte());
-                currentBuilder.setDataSize(binReader.ReadInt32());
-                //TODO see if this is correct.
-                currentBuilder.setStartingIndex(binReader.BaseStream.Position);
-                currentBuilder.setNameSize(binReader.ReadInt16());
-
-                byte[] nameBytes = binReader.ReadBytes(currentBuilder.getNameSize());
-                String tagName = Encoding.UTF8.GetString(nameBytes);
-                currentBuilder.setName(tagName);
-
-                byte[] value = binReader.ReadBytes((int)(currentBuilder.getStartingIndex() - stream.Position) + (int)currentBuilder.getDataSize());
-                currentBuilder.setValueBytes(value);
-                output.Add((T) currentBuilder.proccess());
-            }
-            binReader.Close();
-            return output;
-        }
+        
     }
 }

--- a/ODS/ObjectDataStructure.cs
+++ b/ODS/ObjectDataStructure.cs
@@ -9,7 +9,7 @@ namespace ODS
      * <summary>
      * Primary class of the ObjectDataStructure library.
      * <para>ObjectDataStructure has two storage types: File and Memory. File reads from a file while memory deals with
-     * an array (or buffer) of bytes. This class deals with both types. The type is dependent on the constructor.</para>
+     * an array of bytes. This class deals with both types. The type is dependent on the constructor.</para>
      * <para>Most methods in ODS use what is called a key to reference objects within the file/buffer. A key allows you to grab specific
      * information within the file/buffer. For example: If you wanted a specific string inside of an object with lots of information,
      * you can get that specific string without any other data. If you have an object named Car and you wanted to get a string tag named
@@ -35,7 +35,7 @@ namespace ODS
          * <param name="file">The file to use.</param>
          * <param name="compression">The compression that should be used.</param>
          */
-        public ObjectDataStructure(FileInfo file, Compressor compression)
+        public ObjectDataStructure(FileInfo file, ICompressor compression)
         {
             this.odsInternal = new ODSFile(file, compression);
         }
@@ -54,7 +54,7 @@ namespace ODS
          * <param name="data">Pre-existing data that should be inserted into the memory stream.</param>
          * <param name="compressor">The compression format the data uses.</param>
          */
-        public ObjectDataStructure(byte[] data, Compressor compressor)
+        public ObjectDataStructure(byte[] data, ICompressor compressor)
         {
             this.odsInternal = new ODSMem(data, compressor);
         }
@@ -67,14 +67,9 @@ namespace ODS
             this.odsInternal = new ODSMem();
         }
 
-        /*
-         * TODO :: Finish updaing the comments. 
-         * 
-         * 
-         */
-
         /**
-         * <summary>Grab a tag based upon an object key. This method allows you to directly get sub-objects with little overhead.</summary>
+         * <summary>Grab a tag based upon an object key. 
+         * <para>This method allows you to directly get sub-objects with little overhead.</para></summary>
          * <example>
          *      Get("primary.firstsub.secondsub");
          * </example>
@@ -87,7 +82,7 @@ namespace ODS
         }
 
         /**
-         * <summary>Get all of the tags in the file.</summary>
+         * <summary>Get all of the tags in the file or buffer.</summary>
          * <returns>All of the tags. This returns null if the file does not exist.</returns>
          */
         public List<ITag> GetAll()
@@ -96,9 +91,9 @@ namespace ODS
         }
 
         /**
-         * <summary>Save tags to the file. This method will create a new file if one does not exist.
-         * This will overwrite the existing file. To append tags
-         * see #Append(ITag) and #AppendAll(List)</summary>
+         * <summary>Save tags to the file or buffer.
+         * <para>This will overwrite the existing file or buffer. To append tags see <see cref="Append(ITag)"/> and <see cref="AppendAll(List{ITag})"/></para>
+         * </summary>
          * <param name="tags">The list of tags to save.</param>
          */
         public void Save(List<ITag> tags)
@@ -107,7 +102,7 @@ namespace ODS
         }
 
         /**
-         * <summary>Append tags to the end of the file.</summary>
+         * <summary>Append tags to the end of the data.</summary>
          * <param name="tag">The tag to be appended.</param>
          */
         public void Append(ITag tag)
@@ -116,7 +111,7 @@ namespace ODS
         }
 
         /**
-         * <summary>Append a list of tags to the end of the file.</summary>
+         * <summary>Append a list of tags to the end of the data.</summary>
          * <param name="tags">The list of tags.</param>
          */
         public void AppendAll(List<ITag> tags)
@@ -125,7 +120,7 @@ namespace ODS
         }
 
         /**
-         * <summary>Find if a key exists within a file.</summary>
+         * <summary>Find if a key exists within the data.</summary>
          * <param name="key">The key to find.</param>
          * <returns>If the key exists.</returns>
          */
@@ -163,7 +158,7 @@ namespace ODS
          * The tag name written to the file is the name of the specified tag in the value parameter. Any parent objects that do not exist will be created. For example:
          * <code>ObjectOne.ObjectTwo.NewObject.tagName</code> If in the example above <c>NewObject</c> does not exist, than the object will be created with the value tag inside
          * of it. Please see the wiki for a more detailed explanation on this.</para>
-         * <para>When value is null, the specified key is deleted. <c>The key MUST exist or an {@link ODSException} will be thrown.</c></para>
+         * <para>When value is null, the specified key is deleted. <c>The key MUST exist or an <see cref="ODS.Exceptions.ODSException"/> will be thrown.</c></para>
          * </summary>
          * 
          * <param name="key">
@@ -186,7 +181,13 @@ namespace ODS
             odsInternal.Set(key, value);
         }
 
-        public byte[] Export(Compressor compressor)
+        /**
+         * <summary>Get the array of bytes in any compression format.</summary>
+         * 
+         * <param name="compressor">The compression format.</param>
+         * <returns>The array of bytes.</returns>
+         */
+        public byte[] Export(ICompressor compressor)
         {
             return odsInternal.Export(compressor);
         }

--- a/ODS/Tag.cs
+++ b/ODS/Tag.cs
@@ -23,11 +23,5 @@
          * <returns>The tag that is created from the value bytes.</returns>
          */
         Tag<T> CreateFromData(byte[] value);
-
-        /**
-         * <summary>Get the byte id of the tag.</summary>
-         * <returns>The byte id.</returns>
-         */
-        byte GetID();
     }
 }

--- a/ODS/Tags/ByteTag.cs
+++ b/ODS/Tags/ByteTag.cs
@@ -5,37 +5,61 @@ using System.IO;
 
 namespace ODS.Tags
 {
+    /**
+     * <summary>This tag stores byte data.</summary>
+     * <remarks>See <see cref="Tag{T}"/> for the API comments.</remarks>
+     */
     public class ByteTag : Tag<byte>
     {
         private string name;
         private byte value;
 
-        public ByteTag(String name, byte value)
+        /**
+         * <summary>Construct a byte tag.</summary>
+         * <param name="name">The name of the tag.</param>
+         * <param name="value">The value of the tag.</param>
+         */
+        public ByteTag(string name, byte value)
         {
             this.name = name;
             this.value = value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetValue(byte s)
         {
             this.value = s;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetValue()
         {
             return value;
         }
 
-        public void SetName(String name)
+        /**
+         * <inheritdoc/>
+         */
+        public void SetName(string name)
         {
             this.name = name;
         }
 
-        public String GetName()
+        /**
+         * <inheritdoc/>
+         */
+        public string GetName()
         {
             return name;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void WriteData(BigBinaryWriter dos)
         {
             dos.Write(GetID());
@@ -50,12 +74,18 @@ namespace ODS.Tags
             dos.Write(memStream.ToArray());
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public Tag<byte> CreateFromData(byte[] value)
         {
             this.value = value[0];
             return this;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetID()
         {
             return 8;

--- a/ODS/Tags/ByteTag.cs
+++ b/ODS/Tags/ByteTag.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 
 namespace ODS.Tags

--- a/ODS/Tags/CharTag.cs
+++ b/ODS/Tags/CharTag.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 
 namespace ODS.Tags

--- a/ODS/Tags/CharTag.cs
+++ b/ODS/Tags/CharTag.cs
@@ -5,37 +5,60 @@ using System.IO;
 
 namespace ODS.Tags
 {
-    public class CharTag : Tag<Char>
+    /**
+     * <summary>The tag that stores a character.</summary>
+     */
+    public class CharTag : Tag<char>
     {
         private string name;
         private char value;
 
-        public CharTag(String name, char value)
+        /**
+         * <summary>Construct a char tag.</summary>
+         * <param name="name">The name of the tag.</param>
+         * <param name="value">The value of the tag.</param>
+         */
+        public CharTag(string name, char value)
         {
             this.name = name;
             this.value = value;
         }
 
-        public void SetValue(Char s)
+        /**
+         * <inheritdoc/>
+         */
+        public void SetValue(char s)
         {
             this.value = s;
         }
 
-        public Char GetValue()
+        /**
+         * <inheritdoc/>
+         */
+        public char GetValue()
         {
             return value;
         }
 
-        public void SetName(String name)
+        /**
+         * <inheritdoc/>
+         */
+        public void SetName(string name)
         {
             this.name = name;
         }
 
-        public String GetName()
+        /**
+         * <inheritdoc/>
+         */
+        public string GetName()
         {
             return name;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void WriteData(BigBinaryWriter dos)
         {
             dos.Write(GetID());
@@ -50,12 +73,18 @@ namespace ODS.Tags
             dos.Write(memStream.ToArray());
         }
 
-        public Tag<Char> CreateFromData(byte[] value)
+        /**
+         * <inheritdoc/>
+         */
+        public Tag<char> CreateFromData(byte[] value)
         {
             this.value = BitConverter.ToChar(value, 0);
             return this;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetID()
         {
             return 7;

--- a/ODS/Tags/DictionaryTag.cs
+++ b/ODS/Tags/DictionaryTag.cs
@@ -1,7 +1,9 @@
 ﻿using System.Text;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 using System.Collections.Generic;
+
+using ODS.Internal;
 
 namespace ODS.Tags
 {
@@ -62,7 +64,7 @@ namespace ODS.Tags
 
         public Tag<IDictionary<string, T>> CreateFromData(byte[] value)
         {
-            List<T> data = ObjectDataStructure.GetListData<T>(value);
+            List<T> data = InternalUtils.GetListData<T>(value);
             SortedDictionary<string, T> output = new SortedDictionary<string, T>();
             foreach(T tag in data)
             {

--- a/ODS/Tags/DictionaryTag.cs
+++ b/ODS/Tags/DictionaryTag.cs
@@ -8,41 +8,63 @@ using ODS.Internal;
 namespace ODS.Tags
 {
     /**
-     * This is the equivalent of a Map tag in the offical version.
+     * <summary>A tag that stores a disctionary. The key of the dictionary must be a string.</summary>
+     * <remarks>This is the equivalent of a Map tag in the offical version.
      * This tag was renamed to reflect the C# api.
-     * Note: When grabbing a Dictionary from a file ODS assumes that it is a sorted dictionary.
+     * <para>Note: When grabbing a Dictionary from a file ODS assumes that it is a sorted dictionary.</para></remarks>
+     * <typeparam name="T">The data type of the value of the dictionary (Must extend <see cref="ITag"/>).</typeparam>
      */
     public class DictionaryTag<T> : Tag<IDictionary<string, T>> where T : ITag
     {
         private string name;
         private IDictionary<string, T> value;
 
+        /**
+         * <summary>Construct a dictionary tag.</summary>
+         * <param name="name">The name of the tag.</param>
+         * <param name="value">The value of the tag.</param>
+         */
         public DictionaryTag(string name, IDictionary<string, T> value)
         {
             this.name = name;
             this.value = value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetValue(IDictionary<string, T> s)
         {
             this.value = s;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public IDictionary<string, T> GetValue()
         {
             return value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetName(string name)
         {
             this.name = name;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public string GetName()
         {
             return name;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void WriteData(BigBinaryWriter dos)
         {
             dos.Write(GetID());
@@ -62,6 +84,9 @@ namespace ODS.Tags
             dos.Write(memStream.ToArray());
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public Tag<IDictionary<string, T>> CreateFromData(byte[] value)
         {
             List<T> data = InternalUtils.GetListData<T>(value);
@@ -75,6 +100,9 @@ namespace ODS.Tags
             return this;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetID()
         {
             return 10;

--- a/ODS/Tags/DoubleTag.cs
+++ b/ODS/Tags/DoubleTag.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 
 namespace ODS.Tags

--- a/ODS/Tags/DoubleTag.cs
+++ b/ODS/Tags/DoubleTag.cs
@@ -5,37 +5,60 @@ using System.IO;
 
 namespace ODS.Tags
 {
-    public class DoubleTag : Tag<Double>
+    /**
+     * <summary>A tag that contains a double.</summary>
+     */
+    public class DoubleTag : Tag<double>
     {
         private string name;
-        private Double value;
+        private double value;
 
-        public DoubleTag(String name, Double value)
+        /**
+         * <summary>Construct a double tag.</summary>
+         * <param name="name">The name of the tag.</param>
+         * <param name="value">The value of the tag.</param>
+         */
+        public DoubleTag(string name, double value)
         {
             this.name = name;
             this.value = value;
         }
 
-        public void SetValue(Double s)
+        /**
+         * <inheritdoc/>
+         */
+        public void SetValue(double s)
         {
             this.value = s;
         }
 
-        public Double GetValue()
+        /**
+         * <inheritdoc/>
+         */
+        public double GetValue()
         {
             return value;
         }
 
-        public void SetName(String name)
+        /**
+         * <inheritdoc/>
+         */
+        public void SetName(string name)
         {
             this.name = name;
         }
 
-        public String GetName()
+        /**
+         * <inheritdoc/>
+         */
+        public string GetName()
         {
             return name;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void WriteData(BigBinaryWriter dos)
         {
             dos.Write(GetID());
@@ -50,12 +73,18 @@ namespace ODS.Tags
             dos.Write(memStream.ToArray());
         }
 
-        public Tag<Double> CreateFromData(byte[] value)
+        /**
+         * <inheritdoc/>
+         */
+        public Tag<double> CreateFromData(byte[] value)
         {
             this.value = ByteConverter.ToDouble(value);
             return this;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetID()
         {
             return 4;

--- a/ODS/Tags/FloatTag.cs
+++ b/ODS/Tags/FloatTag.cs
@@ -5,37 +5,60 @@ using System.IO;
 
 namespace ODS.Tags
 {
+    /**
+     * <summary>A tag that contains a float.</summary>
+     */
     public class FloatTag : Tag<float>
     {
         private string name;
         private float value;
 
-        public FloatTag(String name, float value)
+        /**
+         * <summary>Construct a float tag.</summary>
+         * <param name="name">The name of the tag.</param>
+         * <param name="value">The value of the tag.</param>
+         */
+        public FloatTag(string name, float value)
         {
             this.name = name;
             this.value = value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetValue(float s)
         {
             this.value = s;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public float GetValue()
         {
             return value;
         }
 
-        public void SetName(String name)
+        /**
+         * <inheritdoc/>
+         */
+        public void SetName(string name)
         {
             this.name = name;
         }
 
-        public String GetName()
+        /**
+         * <inheritdoc/>
+         */
+        public string GetName()
         {
             return name;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void WriteData(BigBinaryWriter dos)
         {
             dos.Write(GetID());
@@ -50,12 +73,18 @@ namespace ODS.Tags
             dos.Write(memStream.ToArray());
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public Tag<float> CreateFromData(byte[] value)
         {
             this.value = ByteConverter.ToFloat(value);
             return this;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetID()
         {
             return 3;

--- a/ODS/Tags/FloatTag.cs
+++ b/ODS/Tags/FloatTag.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 
 namespace ODS.Tags

--- a/ODS/Tags/IntTag.cs
+++ b/ODS/Tags/IntTag.cs
@@ -5,37 +5,60 @@ using System.IO;
 
 namespace ODS.Tags
 {
+    /**
+     * <summary>A tag that contains an integer.</summary>
+     */
     public class IntTag : Tag<int>
     {
         private string name;
         private int value;
 
-        public IntTag(String name, int value)
+        /**
+         * <summary>Construct an integer tag.</summary>
+         * <param name="name">The name of the tag.</param>
+         * <param name="value">The value of the tag.</param>
+         */
+        public IntTag(string name, int value)
         {
             this.name = name;
             this.value = value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetValue(int s)
         {
             this.value = s;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public int GetValue()
         {
             return value;
         }
 
-        public void SetName(String name)
+        /**
+         * <inheritdoc/>
+         */
+        public void SetName(string name)
         {
             this.name = name;
         }
 
-        public String GetName()
+        /**
+         * <inheritdoc/>
+         */
+        public string GetName()
         {
             return name;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void WriteData(BigBinaryWriter dos)
         {
             dos.Write(GetID());
@@ -50,12 +73,18 @@ namespace ODS.Tags
             dos.Write(memStream.ToArray());
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public Tag<int> CreateFromData(byte[] value)
         {
             this.value = ByteConverter.ToInt32(value);
             return this;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetID()
         {
             return 2;

--- a/ODS/Tags/IntTag.cs
+++ b/ODS/Tags/IntTag.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 
 namespace ODS.Tags

--- a/ODS/Tags/InvalidTag.cs
+++ b/ODS/Tags/InvalidTag.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 using ODS.Exceptions;
 

--- a/ODS/Tags/InvalidTag.cs
+++ b/ODS/Tags/InvalidTag.cs
@@ -7,48 +7,79 @@ using ODS.Exceptions;
 
 namespace ODS.Tags
 {
+    /**
+     * <summary>An InvalidTag represents a custom tag that ODS does not recognize.</summary>
+     * <remarks>This should only be constructed by ODS internally. This class has no other use.</remarks>
+     */
     class InvalidTag : Tag<byte[]>
     {
         private string name;
         private byte[] value;
 
+        /**
+         * <summary>Construct an invalid tag.</summary>
+         * <remarks>This is for internal use only.</remarks>
+         * <param name="name">The name of the tag.</param>
+         * <param name="value">The value of the tag.</param>
+         */
         public InvalidTag(string name, byte[] value)
         {
             this.name = name;
             this.value = value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetValue(byte[] s)
         {
             this.value = s;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte[] GetValue()
         {
             return value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetName(string name)
         {
             this.name = name;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public string GetName()
         {
             return name;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void WriteData(BigBinaryWriter dos)
         {
             throw new ODSException("Cannot write an InvalidTag.");
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public Tag<byte[]> CreateFromData(byte[] value)
         {
             this.value = value;
             return this;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetID()
         {
             return 0;

--- a/ODS/Tags/ListTag.cs
+++ b/ODS/Tags/ListTag.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Text;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 using System.Collections.Generic;
+
+using ODS.Internal;
 
 namespace ODS.Tags
 {
@@ -88,7 +90,7 @@ namespace ODS.Tags
 
         public Tag<List<T>> CreateFromData(byte[] value)
         {
-            this.value = ObjectDataStructure.GetListData<T>(value);
+            this.value = InternalUtils.GetListData<T>(value);
             return this;
         }
 

--- a/ODS/Tags/ListTag.cs
+++ b/ODS/Tags/ListTag.cs
@@ -8,67 +8,132 @@ using ODS.Internal;
 
 namespace ODS.Tags
 {
+    /**
+     * <summary>A tag that contains a list of Tags.</summary>
+     * <typeparam name="T">The type of tag that is stored. T must extend ITag.</typeparam>
+     */
     public class ListTag<T> : Tag<List<T>> where T : ITag
     {
         private string name;
         private List<T> value;
 
-        public ListTag(String name, List<T> value)
+        /**
+         * <summary>Construct a list tag.</summary>
+         * <param name="name">The name of the tag.</param>
+         * <param name="value">The value of the tag.</param>
+         */
+        public ListTag(string name, List<T> value)
         {
             this.name = name;
             this.value = value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetValue(List<T> s)
         {
             this.value = s;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public List<T> GetValue()
         {
             return value;
         }
 
-        public void SetName(String name)
+        /**
+         * <inheritdoc/>
+         */
+        public void SetName(string name)
         {
             this.name = name;
         }
 
-        public String GetName()
+        /**
+         * <inheritdoc/>
+         */
+        public string GetName()
         {
             return name;
         }
 
+        /**
+         * <summary>Add a tag to the list.</summary>
+         * 
+         * <param name="tag">The tag to add.</param>
+         */
         public void AddTag(T tag)
         {
             value.Add(tag);
         }
 
+        /**
+         * <summary>Get a tag at a certain index.</summary>
+         * <param name="i">The index of the desired tag.</param>
+         * <returns>The tag at index i.</returns>
+         */
         public T GetTag(int i)
         {
             return value[i];
         }
 
+        /**
+         * <summary>Get a tag via its name.</summary>
+         * <param name="name">The name of the tag to get.</param>
+         * <returns>The tag with the desired name. (Returns the default if none is found).</returns>
+         */
+        public T GetTag(string name)
+        {
+            foreach(T tag in value){
+                if (tag.GetName() == name)
+                    return tag;
+            }
+
+            return default;
+        }
+
+       /**
+        * <summary>Remove a tag via instance.</summary>
+        * <param name="tag">The tag to remove.</param>
+        */
         public void RemoveTag(T tag)
         {
             value.Remove(tag);
         }
 
+        /**
+         * <summary>Remove a tag via its index.</summary>
+         * <param name="tag">The index of the tag to remove.</param>
+         */
         public void RemoveTag(int tag)
         {
             value.RemoveAt(tag);
         }
 
+        /**
+         * <summary>Remove all tags for the list.</summary>
+         */
         public void RemoveAllTags()
         {
             value.Clear();
         }
 
+        /**
+         * <summary>Get the index of the specified tag.</summary>
+         * <param name="tag">The tag that you want the index of.</param>
+         * <returns>The index of the specified tag.</returns>
+         */
         public int IndexOf(T tag)
         {
             return value.IndexOf(tag);
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void WriteData(BigBinaryWriter dos)
         {
             dos.Write(GetID());
@@ -88,12 +153,18 @@ namespace ODS.Tags
             dos.Write(memStream.ToArray());
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public Tag<List<T>> CreateFromData(byte[] value)
         {
             this.value = InternalUtils.GetListData<T>(value);
             return this;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetID()
         {
             return 9;

--- a/ODS/Tags/LongTag.cs
+++ b/ODS/Tags/LongTag.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 
 namespace ODS.Tags

--- a/ODS/Tags/LongTag.cs
+++ b/ODS/Tags/LongTag.cs
@@ -5,37 +5,60 @@ using System.IO;
 
 namespace ODS.Tags
 {
+    /**
+     * <summary>A tag that contains a long.</summary>
+     */
     public class LongTag : Tag<long>
     {
         private string name;
         private long value;
 
-        public LongTag(String name, long value)
+        /**
+         * <summary>Construct a long tag.</summary>
+         * <param name="name">The name of the tag.</param>
+         * <param name="value">The value of the tag.</param>
+         */
+        public LongTag(string name, long value)
         {
             this.name = name;
             this.value = value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetValue(long s)
         {
             this.value = s;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public long GetValue()
         {
             return value;
         }
 
-        public void SetName(String name)
+        /**
+         * <inheritdoc/>
+         */
+        public void SetName(string name)
         {
             this.name = name;
         }
 
-        public String GetName()
+        /**
+         * <inheritdoc/>
+         */
+        public string GetName()
         {
             return name;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void WriteData(BigBinaryWriter dos)
         {
             dos.Write(GetID());
@@ -50,12 +73,18 @@ namespace ODS.Tags
             dos.Write(memStream.ToArray());
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public Tag<long> CreateFromData(byte[] value)
         {
             this.value = ByteConverter.ToInt64(value);
             return this;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetID()
         {
             return 6;

--- a/ODS/Tags/ObjectTag.cs
+++ b/ODS/Tags/ObjectTag.cs
@@ -8,78 +8,135 @@ using ODS.Internal;
 
 namespace ODS.Tags
 {
+    /**
+     * <summary>A tag that contains an object.</summary>
+     */
     public class ObjectTag : Tag<List<ITag>>
     {
         private string name;
         private List<ITag> value;
 
+        /**
+         * <summary>Construct an object tag.</summary>
+         * <param name="name">The name of the tag.</param>
+         * <param name="value">The list of Tags that the object contains.</param>
+         */
         public ObjectTag(string name, List<ITag> value)
         {
             this.name = name;
             this.value = value;
         }
 
+        /**
+         * <summary>Construct an object tag with no existing tags.</summary>
+         * <param name="name">The name of the tag.</param>
+         */
         public ObjectTag(string name)
         {
             this.name = name;
             this.value = new List<ITag>();
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetValue(List<ITag> s)
         {
             this.value = s;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public List<ITag> GetValue()
         {
             return value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetName(string name)
         {
             this.name = name;
         }
 
-        public String GetName()
+        /**
+         * <inheritdoc/>
+         */
+        public string GetName()
         {
             return name;
         }
 
+        /**
+         * <summary>Add a tag to the object.</summary>
+         * <param name="tag">The tag to add.</param>
+         */
         public void AddTag(ITag tag)
         {
             value.Add(tag);
         }
 
+        /**
+         * <summary>Get the tag at a specified index.</summary>
+         * <param name="i">The index of the desired tag.</param>
+         * <returns>The tag at a specified index.</returns>
+         */
         public ITag GetTag(int i)
         {
             return value[i];
         }
 
+        /**
+         * <summary>Get a tag by name.</summary>
+         * <param name="name">The name of the desired tag.</param>
+         * <returns>A tag with a specific name. (Null if not found)</returns>
+         */
         public ITag GetTag(string name)
         {
             return value.Find(tag => tag.GetName() == name);
         }
 
+        /**
+         * <summary>Remove a tag from the object.</summary>
+         * <param name="tag">The tag to remove.</param>
+         */
         public void RemoveTag(ITag tag)
         {
             value.Remove(tag);
         }
 
+        /**
+         * <summary>Remove a tag at a specified index.</summary>
+         * <param name="tag">The index of the tag to remove.</param>
+         */
         public void RemoveTag(int tag)
         {
             value.RemoveAt(tag);
         }
 
+        /**
+         * <summary>Remove all tags from the object.</summary>
+         */
         public void RemoveAllTags()
         {
             value.Clear();
         }
 
+        /**
+         * <summary>Check to see if the object contains a tag with a certain name.</summary>
+         * <param name="name">The name to check.</param>
+         * <returns>If the object a tag with the desired name.</returns>
+         */
         public bool HasTag(string name)
         {
             return value.Find(tag => tag.GetName() == name) != null;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void WriteData(BigBinaryWriter dos)
         {
             dos.Write(GetID());
@@ -98,12 +155,18 @@ namespace ODS.Tags
             dos.Write(memStream.ToArray());
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public Tag<List<ITag>> CreateFromData(byte[] value)
         {
             this.value = InternalUtils.GetListData<ITag>(value);
             return this;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetID()
         {
             return 11;

--- a/ODS/Tags/ObjectTag.cs
+++ b/ODS/Tags/ObjectTag.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Text;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 using System.Collections.Generic;
+
+using ODS.Internal;
 
 namespace ODS.Tags
 {
@@ -98,7 +100,7 @@ namespace ODS.Tags
 
         public Tag<List<ITag>> CreateFromData(byte[] value)
         {
-            this.value = ObjectDataStructure.GetListData<ITag>(value);
+            this.value = InternalUtils.GetListData<ITag>(value);
             return this;
         }
 

--- a/ODS/Tags/ShortTag.cs
+++ b/ODS/Tags/ShortTag.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 
 namespace ODS.Tags

--- a/ODS/Tags/ShortTag.cs
+++ b/ODS/Tags/ShortTag.cs
@@ -5,37 +5,60 @@ using System.IO;
 
 namespace ODS.Tags
 {
+    /**
+     * <summary>A tag that contains a short.</summary>
+     */
     public class ShortTag : Tag<short>
     {
         private string name;
         private short value;
 
-        public ShortTag(String name, short value)
+        /**
+         * <summary>Construct a short tag.</summary>
+         * <param name="name">The name of the tag.</param>
+         * <param name="value">The value of the tag.</param>
+         */
+        public ShortTag(string name, short value)
         {
             this.name = name;
             this.value = value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetValue(short s)
         {
             this.value = s;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public short GetValue()
         {
             return value;
         }
 
-        public void SetName(String name)
+        /**
+         * <inheritdoc/>
+         */
+        public void SetName(string name)
         {
             this.name = name;
         }
 
-        public String GetName()
+        /**
+         * <inheritdoc/>
+         */
+        public string GetName()
         {
             return name;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void WriteData(BigBinaryWriter dos)
         {
             dos.Write(GetID());
@@ -50,12 +73,18 @@ namespace ODS.Tags
             dos.Write(memStream.ToArray());
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public Tag<short> CreateFromData(byte[] value)
         {
             this.value = ByteConverter.ToInt16(value);
             return this;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetID()
         {
             return 5;

--- a/ODS/Tags/StringTag.cs
+++ b/ODS/Tags/StringTag.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Text;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 
 namespace ODS.Tags

--- a/ODS/Tags/StringTag.cs
+++ b/ODS/Tags/StringTag.cs
@@ -5,37 +5,60 @@ using System.IO;
 
 namespace ODS.Tags
 {
+    /**
+     * <summary>A tag that contains a string.</summary>
+     */
     public class StringTag : Tag<string>
     {
         private string name;
         private string value;
 
+        /**
+         * <summary>Construct a string tag.</summary>
+         * <param name="name">The name of the tag.</param>
+         * <param name="value">The value of the tag.</param>
+         */
         public StringTag(string name, string value)
         {
             this.name = name;
             this.value = value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetValue(string s)
         {
             this.value = s;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public string GetValue()
         {
             return value;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void SetName(string name)
         {
             this.name = name;
         }
 
-        public String GetName()
+        /**
+         * <inheritdoc/>
+         */
+        public string GetName()
         {
             return name;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public void WriteData(BigBinaryWriter dos)
         {
             dos.Write(GetID());
@@ -50,12 +73,18 @@ namespace ODS.Tags
             dos.Write(memStream.ToArray());
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public Tag<string> CreateFromData(byte[] value)
         {
             this.value = Encoding.UTF8.GetString(value);
             return this;
         }
 
+        /**
+         * <inheritdoc/>
+         */
         public byte GetID()
         {
             return 1;

--- a/ODSTest/CustomTag.cs
+++ b/ODSTest/CustomTag.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 using ODS;
-using ODS.Stream;
+using ODS.ODSStreams;
 using System.IO;
 
 namespace ODSTest

--- a/ODSTest/Program.cs
+++ b/ODSTest/Program.cs
@@ -12,7 +12,7 @@ namespace ODSTest
     {
         static void Main(string[] args)
         {
-            ObjectDataStructure ods = new ObjectDataStructure(/*new FileInfo(Directory.GetCurrentDirectory() + "\\test3.ods"), new GZIPCompression()*/);
+            ObjectDataStructure ods = new ObjectDataStructure(new FileInfo(Directory.GetCurrentDirectory() + @"\test3.ods"), new GZIPCompression());
             // Register a custom tag.
             ODSUtil.RegisterCustomTag(new CustomTag("", ""));
 

--- a/ODSTest/Program.cs
+++ b/ODSTest/Program.cs
@@ -12,7 +12,7 @@ namespace ODSTest
     {
         static void Main(string[] args)
         {
-            ObjectDataStructure ods = new ObjectDataStructure(new FileInfo(Directory.GetCurrentDirectory() + "\\test3.ods"), new GZIPCompression());
+            ObjectDataStructure ods = new ObjectDataStructure(/*new FileInfo(Directory.GetCurrentDirectory() + "\\test3.ods"), new GZIPCompression()*/);
             // Register a custom tag.
             ODSUtil.RegisterCustomTag(new CustomTag("", ""));
 
@@ -40,6 +40,10 @@ namespace ODSTest
 
             ods.Save(tags);
 
+            ods.Append(new StringTag("Test", "test"));
+
+            ods.GetAll();
+
             // Loading Example
 
             StringTag tag = (StringTag) ods.Get("ExampleKey");
@@ -49,7 +53,9 @@ namespace ODSTest
             StringTag myCarType = (StringTag)myCar.GetTag("type");
             Console.WriteLine("The car is a " + myCarType.GetValue());
 
+            Console.WriteLine("First Name:");
             StringTag ownerFirstName = (StringTag) ods.Get("Car.Owner.firstName");
+            Console.WriteLine("Last Name:");
             StringTag ownerLastName = (StringTag)ods.Get("Car.Owner.lastName");
             Console.WriteLine("The owner of the car is " + ODSUtil.UnWrap(ownerFirstName) + " " + ODSUtil.UnWrap(ownerLastName));
             Console.WriteLine(ods.Find("Car.Owner.firstName"));
@@ -57,6 +63,9 @@ namespace ODSTest
             Console.WriteLine(((CustomTag)ods.Get("Test")).GetValue());
 
             ods.Set("Car.Owner.firstName", new StringTag("firstName", "Example"));
+            ods.ReplaceData("Car.Owner.Age", new IntTag("Age", 3));
+            Console.WriteLine(ODSUtil.UnWrap((IntTag)ods.Get("Car.Owner.Age")));
+            //ods.Set("Car.Owner.Age", new IntTag("Age", 3));
 
         }
     }


### PR DESCRIPTION
This PR is in response to: https://github.com/ryandw11/ODS/pull/6
# Changes
 - Signifigantly improved memory usage by properly handeling memory.
- Added the Memory storage type.
- Changed the compressor format to now get the stream instead of compressing byte arrays directly.
- Updated api to look similar to the new layout in the java version.
- Updated code comments.
- Renamed Stream namespace to ODSStreams to prevent conflicts.

# Examples
```C#
// memory
ObjectDataStructure ods = new ObjectDataStructure();
```
```c#
// memory with existing bytes.
ObjectDataStructure ods = new ObjectDataStructure(arrayOfBytes, new GZIPCompression());
```